### PR TITLE
Ensure UTF-8 is truly the default encoding in all cases

### DIFF
--- a/src/main/java/com/rometools/rome/io/XmlReader.java
+++ b/src/main/java/com/rometools/rome/io/XmlReader.java
@@ -77,7 +77,7 @@ public class XmlReader extends Reader {
     private static final MessageFormat HTTP_EX_3 = new MessageFormat(
             "Invalid encoding, CT-MIME [{0}] CT-Enc [{1}] BOM [{2}] XML guess [{3}] XML prolog [{4}], Invalid MIME");
 
-    private static String staticDefaultEncoding = null;
+    private static String staticDefaultEncoding = UTF_8;
 
     private final String defaultEncoding;
 


### PR DESCRIPTION
Since staticDefaultEncoding was null, defaultEncoding is set to null and in some cases, UTF-8 is then never forced. However, per the javadoc, UTF-8 is the ultimate default.