### PR TITLE
trim period text from document before comparing to period constants

### DIFF
--- a/src/main/java/com/rometools/rome/io/impl/SyModuleParser.java
+++ b/src/main/java/com/rometools/rome/io/impl/SyModuleParser.java
@@ -47,7 +47,7 @@ public class SyModuleParser implements ModuleParser {
         final Element updatePeriod = syndRoot.getChild("updatePeriod", getDCNamespace());
         if (updatePeriod != null) {
             foundSomething = true;
-            sm.setUpdatePeriod(updatePeriod.getText());
+            sm.setUpdatePeriod(updatePeriod.getText().trim());
         }
 
         final Element updateFrequency = syndRoot.getChild("updateFrequency", getDCNamespace());


### PR DESCRIPTION
This is a tiny little 7 char patch to trim whitespace from the period text before setting the update period in SyModule.  SyModuleImpl compares this text to constant strings in hash when setting the update period.  If there's whitespace, an IllegalArgument exception is currently thrown because the text doesn't match exactly.  Whitespace should be irrelevant here.  Period should be trimmed the same way frequency is here.