### PR TITLE
Added: Http URL Redirect check (Status Code 30x) to follow to a new location

### DIFF
--- a/src/main/java/com/rometools/rome/io/XmlReader.java
+++ b/src/main/java/com/rometools/rome/io/XmlReader.java
@@ -234,10 +234,21 @@ public class XmlReader extends Reader {
      * @throws IOException thrown if there is a problem reading the stream of the URLConnection.
      *
      */
-    public XmlReader(final URLConnection conn) throws IOException {
+    public XmlReader(URLConnection conn) throws IOException {
         defaultEncoding = staticDefaultEncoding;
         final boolean lenient = true;
         if (conn instanceof HttpURLConnection) {
+        	//Checks whether the given connection redirects
+        	int status = ((HttpURLConnection)conn).getResponseCode();
+        	if(status == HttpURLConnection.HTTP_MOVED_TEMP
+        			|| status == HttpURLConnection.HTTP_MOVED_PERM
+        			|| status == HttpURLConnection.HTTP_SEE_OTHER) {
+        		//Close the old connection and..
+        		((HttpURLConnection) conn).disconnect();
+        		//...get the new location from the header to create a new connection
+        		conn = new URL(conn.getHeaderField("Location")).openConnection();
+        	}
+        	
             final Package pckg = this.getClass().getPackage();
             if (pckg.getImplementationTitle() != null && pckg.getImplementationVersion() != null) {
                 conn.setRequestProperty("User-Agent", pckg.getImplementationTitle() + "/" + pckg.getImplementationVersion());

--- a/src/main/java/com/rometools/rome/io/XmlReader.java
+++ b/src/main/java/com/rometools/rome/io/XmlReader.java
@@ -238,6 +238,15 @@ public class XmlReader extends Reader {
         defaultEncoding = staticDefaultEncoding;
         final boolean lenient = true;
         if (conn instanceof HttpURLConnection) {
+        	final Package pckg = this.getClass().getPackage();
+        	String userAgent = "ROME";
+            if (pckg.getImplementationTitle() != null && pckg.getImplementationVersion() != null) {
+            	userAgent = pckg.getImplementationTitle() + "/" + pckg.getImplementationVersion();
+            }
+            
+            //Set the user agent accordingly
+            conn.setRequestProperty("User-Agent", userAgent);
+        	
         	//Checks whether the given connection redirects
         	int status = ((HttpURLConnection)conn).getResponseCode();
         	if(status == HttpURLConnection.HTTP_MOVED_TEMP
@@ -247,14 +256,10 @@ public class XmlReader extends Reader {
         		((HttpURLConnection) conn).disconnect();
         		//...get the new location from the header to create a new connection
         		conn = new URL(conn.getHeaderField("Location")).openConnection();
+        		conn.setRequestProperty("User-Agent", userAgent); //Reset user agent to new connection    		
         	}
         	
-            final Package pckg = this.getClass().getPackage();
-            if (pckg.getImplementationTitle() != null && pckg.getImplementationVersion() != null) {
-                conn.setRequestProperty("User-Agent", pckg.getImplementationTitle() + "/" + pckg.getImplementationVersion());
-            } else {
-                conn.setRequestProperty("User-Agent", "ROME");
-            }
+            //
             try {
                 doHttpStream(conn.getInputStream(), conn.getContentType(), lenient);
             } catch (final XmlReaderException ex) {


### PR DESCRIPTION
Hi there

I am suggesting this PR to adapt the XMLReader to double-check the URL connection for a redirect request/status (30x). If so, following to that location before parsing the data which would result in errors. A
```
HttpURLConnection.setFollowRedirects(true);
```
or
```
con.setInstanceFollowRedirects(true);
```
does not work on its own.

This is an initial suggestion as I faced that problem. I am open for any feedback or changes but would love to see such a functionality.


Cheers