### PR TITLE
Support time zone Z in RFC 822 dates

### DIFF
--- a/src/main/java/com/rometools/rome/io/impl/DateParser.java
+++ b/src/main/java/com/rometools/rome/io/impl/DateParser.java
@@ -19,7 +19,9 @@ package com.rometools.rome.io.impl;
 import java.text.DateFormat;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -146,13 +148,31 @@ public class DateParser {
      *
      */
     public static Date parseRFC822(String sDate, final Locale locale) {
-        final int utIndex = sDate.indexOf(" UT");
-        if (utIndex > -1) {
-            final String pre = sDate.substring(0, utIndex);
-            final String post = sDate.substring(utIndex + 3);
-            sDate = pre + " GMT" + post;
-        }
+        sDate = convertUnsupportedTimeZones(sDate);
         return parseUsingMask(RFC822_MASKS, sDate, locale);
+    }
+
+    private static String convertUnsupportedTimeZones(String sDate) {
+        final List<String> unsupportedZeroOffsetTimeZones = Arrays.asList("UT", "Z");
+
+        for (String timeZone : unsupportedZeroOffsetTimeZones) {
+            if (sDate.endsWith(timeZone)) {
+                return replaceLastOccurrence(sDate, timeZone, "UTC");
+            }
+        }
+        return sDate;
+    }
+
+    private static String replaceLastOccurrence(String original, String target, String replacement) {
+        final int lastIndexOfTarget = original.lastIndexOf(target);
+
+        if (lastIndexOfTarget == -1) {
+            return original;
+        } else {
+            return new StringBuilder(original)
+                .replace(lastIndexOfTarget, lastIndexOfTarget + target.length(), replacement)
+                .toString();
+        }
     }
 
     /**

--- a/src/test/java/com/rometools/rome/unittest/TestDateParser.java
+++ b/src/test/java/com/rometools/rome/unittest/TestDateParser.java
@@ -1,6 +1,4 @@
 /*
- * Copyright 2004-2005 Sun Microsystems, Inc.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,8 +10,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
+
 package com.rometools.rome.unittest;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/rometools/rome/unittest/TestDateParser.java
+++ b/src/test/java/com/rometools/rome/unittest/TestDateParser.java
@@ -16,6 +16,9 @@
  */
 package com.rometools.rome.unittest;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -125,6 +128,39 @@ public class TestDateParser extends TestCase {
         // INVALID
         sDate = "X20:10 2000-10-10";
         assertNull(DateParser.parseDate(sDate, Locale.US));
+    }
 
+    public void testRfc822WithZTimeZone() throws Exception {
+        assertDateEquals(
+            "1970-01-01 00:00:00",
+            DateParser.parseRFC822("Thu, 01 Jan 1970 00:00:00 Z", Locale.US));
+    }
+
+    public void testRfc822WithUtTimeZone() throws Exception {
+        assertDateEquals(
+            "1970-01-01 00:00:00",
+            DateParser.parseRFC822("Thu, 01 Jan 1970 00:00:00 UT", Locale.US));
+    }
+
+    public void testRfc822WithUtcTimeZone() throws Exception {
+        assertDateEquals(
+            "1970-01-01 00:00:00",
+            DateParser.parseRFC822("Thu, 01 Jan 1970 00:00:00 UTC", Locale.US));
+    }
+
+    static void assertDateEquals(String expectedString, Date actual) {
+        if (actual == null) {
+            fail("Actual date is null");
+        }
+
+        final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        try {
+            final Date expected = dateFormat.parse(expectedString);
+            assertEquals(expected, actual);
+        } catch (ParseException e) {
+            fail("Failed to parse date: " + e.getMessage());
+        }
     }
 }

--- a/src/test/java/com/rometools/rome/unittest/TestDateParser.java
+++ b/src/test/java/com/rometools/rome/unittest/TestDateParser.java
@@ -16,151 +16,105 @@
  */
 package com.rometools.rome.unittest;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.Locale;
-import java.util.TimeZone;
-
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import com.rometools.rome.io.impl.DateParser;
 
-/**
- *
- * Start of tests for DateParser
- *
- * @author Nick Lothian
- *
- */
-public class TestDateParser extends TestCase {
-    public void testParse() {
-        final Calendar cal = new GregorianCalendar();
-        cal.setTimeZone(TimeZone.getTimeZone("GMT"));
+import org.junit.Test;
 
-        // four-digit year
-        String sDate = "Tue, 19 Jul 2005 23:00:51 GMT";
-        cal.setTime(DateParser.parseRFC822(sDate, Locale.US));
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
-        assertEquals(2005, cal.get(Calendar.YEAR));
-        assertEquals(6, cal.get(Calendar.MONTH)); // month is zero-indexed
-        assertEquals(19, cal.get(Calendar.DAY_OF_MONTH));
-        assertEquals(3, cal.get(Calendar.DAY_OF_WEEK));
-        assertEquals(23, cal.get(Calendar.HOUR_OF_DAY));
-        assertEquals(0, cal.get(Calendar.MINUTE));
-        assertEquals(51, cal.get(Calendar.SECOND));
+public class TestDateParser {
 
-        // two-digit year
-        sDate = "Tue, 19 Jul 05 23:00:51 GMT";
-        cal.setTime(DateParser.parseRFC822(sDate, Locale.US));
-
-        assertEquals(2005, cal.get(Calendar.YEAR));
-        assertEquals(6, cal.get(Calendar.MONTH)); // month is zero-indexed
-        assertEquals(19, cal.get(Calendar.DAY_OF_MONTH));
-        assertEquals(3, cal.get(Calendar.DAY_OF_WEEK));
-        assertEquals(23, cal.get(Calendar.HOUR_OF_DAY));
-        assertEquals(0, cal.get(Calendar.MINUTE));
-        assertEquals(51, cal.get(Calendar.SECOND));
-
-        // four-digit year
-        sDate = "Tue, 19 Jul 2005 23:00:51 UT";
-        cal.setTime(DateParser.parseRFC822(sDate, Locale.US));
-
-        assertEquals(2005, cal.get(Calendar.YEAR));
-        assertEquals(6, cal.get(Calendar.MONTH)); // month is zero-indexed
-        assertEquals(19, cal.get(Calendar.DAY_OF_MONTH));
-        assertEquals(3, cal.get(Calendar.DAY_OF_WEEK));
-        assertEquals(23, cal.get(Calendar.HOUR_OF_DAY));
-        assertEquals(0, cal.get(Calendar.MINUTE));
-        assertEquals(51, cal.get(Calendar.SECOND));
-
-        // two-digit year
-        sDate = "Tue, 19 Jul 05 23:00:51 UT";
-        cal.setTime(DateParser.parseRFC822(sDate, Locale.US));
-
-        assertEquals(2005, cal.get(Calendar.YEAR));
-        assertEquals(6, cal.get(Calendar.MONTH)); // month is zero-indexed
-        assertEquals(19, cal.get(Calendar.DAY_OF_MONTH));
-        assertEquals(3, cal.get(Calendar.DAY_OF_WEEK));
-        assertEquals(23, cal.get(Calendar.HOUR_OF_DAY));
-        assertEquals(0, cal.get(Calendar.MINUTE));
-        assertEquals(51, cal.get(Calendar.SECOND));
-
-        // RFC822
-        sDate = "Tue, 19 Jul 2005 23:00:51 GMT";
-        assertNotNull(DateParser.parseDate(sDate, Locale.US));
-
-        // RFC822
-        sDate = "Tue, 19 Jul 05 23:00:51 GMT";
-        assertNotNull(DateParser.parseDate(sDate, Locale.US));
-
-        final Calendar c = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
-        c.set(2000, Calendar.JANUARY, 01, 0, 0, 0);
-        final Date expectedDate = c.getTime();
-
-        // W3C
-        sDate = "2000-01-01T00:00:00Z";
-        assertEquals(expectedDate.getTime() / 1000, DateParser.parseDate(sDate, Locale.US).getTime() / 1000);
-
-        // W3C
-        sDate = "2000-01-01T00:00Z";
-        assertEquals(expectedDate.getTime() / 1000, DateParser.parseDate(sDate, Locale.US).getTime() / 1000);
-
-        // W3C
-        sDate = "2000-01-01";
-        assertEquals(expectedDate.getTime() / 1000, DateParser.parseDate(sDate, Locale.US).getTime() / 1000);
-
-        // W3C
-        sDate = "2000-01";
-        assertEquals(expectedDate.getTime() / 1000, DateParser.parseDate(sDate, Locale.US).getTime() / 1000);
-
-        // W3C
-        sDate = "2000";
-        assertEquals(expectedDate.getTime() / 1000, DateParser.parseDate(sDate, Locale.US).getTime() / 1000);
-
-        // EXTRA
-        sDate = "18:10 2000/10/10";
-        assertNotNull(DateParser.parseDate(sDate, Locale.US));
-
-        // INVALID
-        sDate = "X20:10 2000-10-10";
-        assertNull(DateParser.parseDate(sDate, Locale.US));
+    @Test
+    public void testW3c() {
+        assertEquals(date("2005-07-19 17:00:42"),
+                     DateParser.parseW3CDateTime("2005-07-19T17:00:42Z", Locale.US));
     }
 
-    public void testRfc822WithZTimeZone() throws Exception {
-        assertDateEquals(
-            "1970-01-01 00:00:00",
-            DateParser.parseRFC822("Thu, 01 Jan 1970 00:00:00 Z", Locale.US));
+    @Test
+    public void testW3cNoSeconds() {
+        assertEquals(date("2005-07-19 17:00:00"),
+                     DateParser.parseW3CDateTime("2005-07-19T17:00Z", Locale.US));
     }
 
-    public void testRfc822WithUtTimeZone() throws Exception {
-        assertDateEquals(
-            "1970-01-01 00:00:00",
-            DateParser.parseRFC822("Thu, 01 Jan 1970 00:00:00 UT", Locale.US));
+    @Test
+    public void testW3cNoTime() {
+        assertEquals(date("2005-07-19 00:00:00"),
+                     DateParser.parseW3CDateTime("2005-07-19", Locale.US));
     }
 
-    public void testRfc822WithUtcTimeZone() throws Exception {
-        assertDateEquals(
-            "1970-01-01 00:00:00",
-            DateParser.parseRFC822("Thu, 01 Jan 1970 00:00:00 UTC", Locale.US));
+    @Test
+    public void testW3cOnlyYearAndMonth() {
+        assertEquals(date("2005-07-01 00:00:00"),
+                     DateParser.parseW3CDateTime("2005-07", Locale.US));
     }
 
-    static void assertDateEquals(String expectedString, Date actual) {
-        if (actual == null) {
-            fail("Actual date is null");
-        }
+    @Test
+    public void testW3cOnlyYear() {
+        assertEquals(date("2005-01-01 00:00:00"),
+                     DateParser.parseW3CDateTime("2005", Locale.US));
+    }
 
+    @Test
+    public void testRfc822FourDigitYear() {
+        assertEquals(date("2005-07-19 17:00:42"),
+                     DateParser.parseRFC822("Tue, 19 Jul 2005 17:00:42 GMT", Locale.US));
+    }
+
+    @Test
+    public void testRfc822TwoDigitYear() {
+        assertEquals(date("2005-07-19 17:00:42"),
+                     DateParser.parseRFC822("Tue, 19 Jul 05 17:00:42 GMT", Locale.US));
+    }
+
+    @Test
+    public void testRfc822WithUtTimeZone() {
+        assertEquals(date("2005-07-19 17:00:42"),
+                     DateParser.parseRFC822("Tue, 19 Jul 2005 17:00:42 UT", Locale.US));
+    }
+
+    @Test
+    public void testRfc822WithUtcTimeZone() {
+        assertEquals(date("2005-07-19 17:00:42"),
+                     DateParser.parseRFC822("Tue, 19 Jul 2005 17:00:42 UTC", Locale.US));
+    }
+
+    @Test
+    public void testRfc822WithZTimeZone() {
+        assertEquals(date("2005-07-19 17:00:42"),
+                     DateParser.parseRFC822("Tue, 19 Jul 2005 17:00:42 Z", Locale.US));
+    }
+
+    @Test
+    public void testExtraMaskInRomePropertiesFile() {
+        assertEquals(date("2005-07-19 17:00:00", TimeZone.getDefault()),
+                     DateParser.parseDate("17:00 2005/07/19", Locale.US));
+    }
+
+    @Test
+    public void testInvalidDate() {
+        assertNull(DateParser.parseDate("X00:00 2005-07-19", Locale.US));
+    }
+
+    static Date date(String dateString) {
+        return date(dateString, TimeZone.getTimeZone("UTC"));
+    }
+
+    static Date date(String dateString, TimeZone timeZone) {
         final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        dateFormat.setTimeZone(timeZone);
 
         try {
-            final Date expected = dateFormat.parse(expectedString);
-            assertEquals(expected, actual);
+            return dateFormat.parse(dateString);
         } catch (ParseException e) {
-            fail("Failed to parse date: " + e.getMessage());
+            throw new IllegalArgumentException("Failed to parse date", e);
         }
     }
 }


### PR DESCRIPTION
From RFC 822[1]:
```
zone        =  "UT"  / "GMT"                ; Universal Time
                                            ; North American : UT
            /  "EST" / "EDT"                ;  Eastern:  - 5/ - 4
            /  "CST" / "CDT"                ;  Central:  - 6/ - 5
            /  "MST" / "MDT"                ;  Mountain: - 7/ - 6
            /  "PST" / "PDT"                ;  Pacific:  - 8/ - 7
            /  1ALPHA                       ; Military: Z = UT;
...
```
`SimpleDateFormat` supports neither `Z` nor `UT`, so they need to be replaced with `GMT`/`UTC`.

Fixes #192 and also happens to fix #205 

[1] http://www.w3.org/Protocols/rfc822/#z28