### PR TITLE
Fix small code problems

### DIFF
--- a/src/main/java/com/rometools/rome/io/WireFeedInput.java
+++ b/src/main/java/com/rometools/rome/io/WireFeedInput.java
@@ -204,11 +204,14 @@ public class WireFeedInput {
     public WireFeed build(final File file) throws FileNotFoundException, IOException, IllegalArgumentException, FeedException {
         WireFeed feed;
         Reader reader = new FileReader(file);
-        if (xmlHealerOn) {
-            reader = new XmlFixerReader(reader);
+        try {
+            if (xmlHealerOn) {
+                reader = new XmlFixerReader(reader);
+            }
+            feed = this.build(reader);
+        } finally {
+            reader.close();
         }
-        feed = this.build(reader);
-        reader.close();
         return feed;
     }
 

--- a/src/main/java/com/rometools/rome/io/WireFeedOutput.java
+++ b/src/main/java/com/rometools/rome/io/WireFeedOutput.java
@@ -185,8 +185,11 @@ public class WireFeedOutput {
      */
     public void output(final WireFeed feed, final File file, final boolean prettyPrint) throws IllegalArgumentException, IOException, FeedException {
         final Writer writer = new FileWriter(file);
-        this.output(feed, writer, prettyPrint);
-        writer.close();
+        try {
+            this.output(feed, writer, prettyPrint);
+        } finally {
+            writer.close();
+        }
     }
 
     /**

--- a/src/main/java/com/rometools/rome/io/XmlReader.java
+++ b/src/main/java/com/rometools/rome/io/XmlReader.java
@@ -518,7 +518,7 @@ public class XmlReader extends Reader {
     private String calculateHttpEncoding(final String cTMime, final String cTEnc, final String bomEnc, final String xmlGuessEnc, final String xmlEnc,
             final InputStream is, final boolean lenient) throws IOException {
         String encoding;
-        if (lenient & xmlEnc != null) {
+        if (lenient && xmlEnc != null) {
             encoding = xmlEnc;
         } else {
             final boolean appXml = isAppXml(cTMime);

--- a/src/main/java/com/rometools/rome/io/impl/Atom03Generator.java
+++ b/src/main/java/com/rometools/rome/io/impl/Atom03Generator.java
@@ -283,7 +283,7 @@ public class Atom03Generator extends BaseWireFeedGenerator {
 
         final String rel = link.getRel();
         if (rel != null) {
-            final Attribute relAttribute = new Attribute("rel", rel.toString());
+            final Attribute relAttribute = new Attribute("rel", rel);
             linkElement.setAttribute(relAttribute);
         }
 
@@ -351,7 +351,7 @@ public class Atom03Generator extends BaseWireFeedGenerator {
 
         final String mode = content.getMode();
         if (mode != null) {
-            final Attribute modeAttribute = new Attribute("mode", mode.toString());
+            final Attribute modeAttribute = new Attribute("mode", mode);
             contentElement.setAttribute(modeAttribute);
         }
 


### PR DESCRIPTION
Fixes #30
This are the changes from a 10-year-old patch. I left out changes to the `clone()` methods, because Java cloning is considered broken anyway.