### PR TITLE
Configure OSGi bundling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,35 @@
                     <content>${project.build.directory}/site</content>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            com.rometools.rome.feed,
+                            com.rometools.rome.feed.atom,
+                            com.rometools.rome.feed.impl,
+                            com.rometools.rome.feed.module,
+                            com.rometools.rome.feed.rss,
+                            com.rometools.rome.feed.synd,
+                            com.rometools.rome.io,
+                        </Export-Package>
+                        <Import-Package>
+                            org.jdom2,
+                            org.jdom2.filter,
+                            org.jdom2.input,
+                            org.jdom2.input.sax,
+                            org.jdom2.output,
+                            org.slf4j,
+                            org.w3c.dom,
+                            org.xml.sax
+                        </Import-Package>
+                        <_exportcontents>com.rometools.utils</_exportcontents>
+                        <Embed-Dependency>rome-utils</Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Fixes #204

I don’t expect this pull request to be merged as is. I am by no means an expert in OSGi. But I did spend quite some time figuring this out and I think it works. Please review and ask questions if anything is unclear.

I configured three bundles as depicted below. Boxes are bundles, inside are maven modules. The changes are spread between four repos: current, https://github.com/rometools/rome-parent/issues/2, https://github.com/rometools/rome-modules/issues/38 and https://github.com/rometools/rome-fetcher/issues/20.

```
1------------+  2--------------+  3--------------+
| rome       |  | rome         |  | rome-fetcher |
| rome-utils |  | rome-utils   |  +--------------+
+------------+  | rome-modules |
                +--------------+
```

**Why bundle rome-modules together with rome?**

Because Rome has a fragile class loading system for modules. Basically `rome` classes need to load `rome-modules` classes. It’s not easily achievable in OSGi if they are in separate bundles. So the idea is that if you need `rome-modules`, you use the bundle that contains both `rome` and `rome-modules`.

**How will it work with custom modules?**

Well, it won’t. Neither it used to. The problem is that you want Rome to load classes from an arbitrary external bundle. One possible solution is to pass your `ClassLoader` to Rome. Luckily Rome has [ConfigurableClassLoader](https://github.com/rometools/rome/blob/master/src/main/java/com/rometools/rome/feed/impl/ConfigurableClassLoader.java). Unfortunately Rome will use the configured `ClassLoader` to load everything, where "everything" includes Rome classes and resources. This is something that can be fixed though.

**Have you tested it?**

Yes. I ran it in Karaf. I also wrote ~~an automated test. It includes only basic feed parsing, but can be extended~~ [automated tests](https://github.com/mishako/rome-osgi-test/tree/master/src/test/java/com/rometools/rome/osgi).