### PR TITLE
Fix setting xml features

### DIFF
--- a/src/main/java/com/rometools/rome/io/WireFeedInput.java
+++ b/src/main/java/com/rometools/rome/io/WireFeedInput.java
@@ -370,8 +370,8 @@ public class WireFeedInput {
     
     private void setFeature(SAXBuilder saxBuilder, XMLReader parser, String feature, boolean value) {
         try {
-            saxBuilder.setFeature(feature, true);
-            parser.setFeature(feature, true);
+            saxBuilder.setFeature(feature, value);
+            parser.setFeature(feature, value);
         } catch (final SAXNotRecognizedException e) {
             // ignore
         } catch (final SAXNotSupportedException e) {


### PR DESCRIPTION
The argument of the method has been unused leading to all of the
features being set to true regardless of the passed argument value.