### PR TITLE
#268: Maven plugin and dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
+                    <version>3.5.1</version>
                     <configuration>
                         <source>1.6</source>
                         <target>1.6</target>
@@ -78,11 +78,23 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-scm-publish-plugin</artifactId>
-                    <version>1.0</version>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>2.8.1</version>
                 </plugin>
-                <!-- The following plugin doesn't modify the build. It is 
-                    only used to hide irrelevant warnings in Eclipse -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                    <configuration>
+                        <deployAtEnd>true</deployAtEnd>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-scm-publish-plugin</artifactId>
+                    <version>1.1</version>
+                </plugin>
+                <!-- The following plugin doesn't modify the build. It is only used to hide irrelevant warnings in Eclipse -->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
@@ -130,7 +142,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -170,18 +181,18 @@
             <dependency>
                 <groupId>org.jdom</groupId>
                 <artifactId>jdom2</artifactId>
-                <version>2.0.5</version>
+                <version>2.0.6</version>
             </dependency>
             <!-- Logging -->
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.10</version>
+                <version>1.7.16</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.1.2</version>
+                <version>1.1.3</version>
             </dependency>
             <!-- JUnit -->
             <dependency>
@@ -226,7 +237,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.3.2</version>
+                <version>3.4</version>
             </dependency>
             <dependency>
                 <groupId>commons-beanutils</groupId>

--- a/rome-certiorem/src/test/java/com/rometools/certiorem/hub/DeltaSyndFeedInfoTest.java
+++ b/rome-certiorem/src/test/java/com/rometools/certiorem/hub/DeltaSyndFeedInfoTest.java
@@ -1,62 +1,41 @@
 /*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+ * To change this template, choose Tools | Templates and open the template in the editor.
  */
 package com.rometools.certiorem.hub;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 
-import org.junit.Before;
 import org.junit.Test;
 
-import com.rometools.certiorem.hub.DeltaFeedInfoCache;
 import com.rometools.fetcher.impl.HashMapFeedInfoCache;
 import com.rometools.fetcher.impl.HttpURLFeedFetcher;
 import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
 
-/**
- *
- * @author najmi
- */
 public class DeltaSyndFeedInfoTest {
 
-    private DeltaFeedInfoCache feedInfoCache;
-    private HttpURLFeedFetcher feedFetcher;
-    private SyndFeed feed;
-
-    @Before
-    public void setUp() {
-        feedInfoCache = new DeltaFeedInfoCache(new HashMapFeedInfoCache());
-        feedFetcher = new HttpURLFeedFetcher(feedInfoCache);
-    }
-
-    /**
-     * Test of getSyndFeed method, of class DeltaSyndFeedInfo.
-     */
     @Test
     public void testGetSyndFeed() throws Exception {
 
-        feed = feedFetcher.retrieveFeed(getFeedUrl());
-        List<SyndEntry> entries = feed.getEntries();
-        assertTrue(!entries.isEmpty());
+        final URL url = new URL("https://news.google.com/news?pz=1&cf=all&ned=us&hl=en&output=rss");
 
-        // Fetch again and this time the entries should be empty as none have
-        // changed.
-        feed = feedFetcher.retrieveFeed(getFeedUrl());
-        entries = feed.getEntries();
-        assertTrue(entries.isEmpty());
-    }
+        final DeltaFeedInfoCache feedInfoCache = new DeltaFeedInfoCache(new HashMapFeedInfoCache());
+        final HttpURLFeedFetcher feedFetcher = new HttpURLFeedFetcher(feedInfoCache);
 
-    private URL getFeedUrl() throws IOException {
-        final URL feedUrl = new URL("http://news.google.com/news?pz=1&cf=all&ned=us&hl=en&output=rss");
-        // URL feedUrl = new
-        // URL("http://newsrss.bbc.co.uk/rss/newsonline_world_edition/front_page/rss.xml");
-        return feedUrl;
+        // the first time the feed should not be empty
+        final SyndFeed firstFeed = feedFetcher.retrieveFeed(url);
+        final List<SyndEntry> firstEntries = firstFeed.getEntries();
+        assertFalse(firstEntries.isEmpty());
+
+        // fetch once again and this time the entries should be empty because nothing has changed
+        final SyndFeed secondFeed = feedFetcher.retrieveFeed(url);
+        final List<SyndEntry> secondEntries = secondFeed.getEntries();
+        assertTrue(secondEntries.isEmpty());
+
     }
 
 }


### PR DESCRIPTION
maven-compiler-plugin 3.1 → 3.5.1
maven-project-info-reports-plugin 2.7 → 2.8.1
maven-scm-publish-plugin 1.0 → 1.1
jdom2 2.0.5 → 2.0.6
slf4j-api 1.7.10 → 1.7.16
logback-classic 1.1.2 → 1.1.3
commons-lang3 3.3.2 → 3.4