### PR TITLE
Use RSS v2 parser by default

### DIFF
--- a/rome/src/main/java/com/rometools/rome/io/impl/RSS20Parser.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/RSS20Parser.java
@@ -51,7 +51,8 @@ public class RSS20Parser extends RSS094Parser {
 
     @Override
     public boolean isMyType(final Document document) {
-        return rootElementMatches(document) && versionMatches(document);
+        return rootElementMatches(document)
+               && (versionMatches(document) || versionAbsent(document));
     }
 
     private boolean rootElementMatches(final Document document) {
@@ -62,5 +63,9 @@ public class RSS20Parser extends RSS094Parser {
         final Attribute version = document.getRootElement().getAttribute("version");
         return (version != null)
                && version.getValue().trim().startsWith(getRSSVersion());
+    }
+
+    private boolean versionAbsent(final Document document) {
+        return document.getRootElement().getAttribute("version") == null;
     }
 }

--- a/rome/src/test/java/com/rometools/rome/io/impl/RSS20ParserTest.java
+++ b/rome/src/test/java/com/rometools/rome/io/impl/RSS20ParserTest.java
@@ -44,4 +44,10 @@ public class RSS20ParserTest {
         document.setRootElement(new Element("rss").setAttribute("version", "2.0test"));
         assertTrue(parser.isMyType(document));
     }
+
+    @Test
+    public void testIsMyTypeVersionAbsent() {
+        document.setRootElement(new Element("rss"));
+        assertTrue(parser.isMyType(document));
+    }
 }


### PR DESCRIPTION
Changed RSS v2 parser to match any feed that has "rss" as root element.
This makes Rome more lenient when handling feeds that don't adhere to
the RSS spec, namely have the "version" attribute missing.

Fixes #186