### PR TITLE
Parse units in filesizes in Media RSS

### DIFF
--- a/rome-modules/src/test/java/com/rometools/modules/mediarss/MediaModuleTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/mediarss/MediaModuleTest.java
@@ -15,14 +15,13 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.List;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
 import com.rometools.modules.AbstractTestCase;
-import com.rometools.modules.mediarss.MediaEntryModule;
-import com.rometools.modules.mediarss.MediaModule;
 import com.rometools.modules.mediarss.types.MediaContent;
 import com.rometools.modules.mediarss.types.Rating;
 import com.rometools.modules.mediarss.types.Thumbnail;
@@ -89,6 +88,16 @@ public class MediaModuleTest extends AbstractTestCase {
                 assertEquals(entries.get(i).getModule(MediaModule.URI), feed2.getEntries().get(i).getModule(MediaModule.URI));
             }
         }
+    }
+
+
+    public void testParseFileSizeWithUnits() throws Exception {
+        final SyndFeed feed = getSyndFeed("org/rometools/feed/module/mediarss/filesize-with-unit.xml");
+        final List<SyndEntry> entries = feed.getEntries();
+
+        final MediaEntryModule module = (MediaEntryModule) entries.get(0).getModule(MediaModule.URI);
+        Long parsedFileSize = module.getMediaContents()[0].getFileSize();
+        assertThat(parsedFileSize, is(new BigDecimal(1000).pow(3).longValue()));
     }
 
     /**

--- a/rome-modules/src/test/java/com/rometools/modules/mediarss/io/MediaModuleParserTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/mediarss/io/MediaModuleParserTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rometools.modules.mediarss.io;
+
+import com.rometools.modules.AbstractTestCase;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+import java.math.BigDecimal;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class MediaModuleParserTest extends AbstractTestCase {
+
+    public MediaModuleParserTest(String testName) {
+        super(testName);
+    }
+
+    public static Test suite() {
+        return new TestSuite(MediaModuleParserTest.class);
+    }
+
+    public void testParsesFileSizeWithoutUnit() {
+        assertThat(MediaModuleParser.parseFileSize("1234567"), is(1234567L));
+    }
+
+    public void testParsesFileSizeWithByteUnit() {
+        assertThat(MediaModuleParser.parseFileSize("1B"), is(1L));
+    }
+
+    public void testParsesFileSizeWithKiloByteUnit() {
+        assertThat(MediaModuleParser.parseFileSize("1KB"), is(1000L));
+    }
+
+    public void testParsesFileSizeWithMegaByteUnit() {
+        assertThat(MediaModuleParser.parseFileSize("1MB"), is(new BigDecimal(1000).pow(2).longValue()));
+    }
+
+    public void testParsesFileSizeWithGigaByteUnit() {
+        assertThat(MediaModuleParser.parseFileSize("1GB"), is(new BigDecimal(1000).pow(3).longValue()));
+    }
+
+    public void testParsesFileSizeWithTeraByteUnit() {
+        assertThat(MediaModuleParser.parseFileSize("1TB"), is(new BigDecimal(1000).pow(4).longValue()));
+    }
+
+    public void testParsesFileSizeHandlesSpaces() {
+        assertThat(MediaModuleParser.parseFileSize(" 1 KB "), is(new BigDecimal(1000).longValue()));
+    }
+
+    public void testParsesFileSizeHandlesDecimals() {
+        assertThat(MediaModuleParser.parseFileSize("1.23KB"), is(new BigDecimal(1230).longValue()));
+    }
+
+    public void testThrowsExceptionOnInvalidFileSize() {
+        try{
+            MediaModuleParser.parseFileSize("reallybig");
+            fail("Exception should've been thrown for invalid file size");
+        } catch(NumberFormatException ignore) {}
+    }
+}

--- a/rome-modules/src/test/resources/org/rometools/feed/module/mediarss/filesize-with-unit.xml
+++ b/rome-modules/src/test/resources/org/rometools/feed/module/mediarss/filesize-with-unit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+    <channel>
+        <item>
+            <media:content url="http://localhost" fileSize="1GB"/>
+        </item>
+    </channel>
+</rss>


### PR DESCRIPTION
Had issues with the fileSizes-attribute while parsing a bunch of media rss feeds. It seems like some specify MB/GB as part of filesize. Which is not really compatible with Media RSS-specification (http://www.rssboard.org/media-rss) which specifies fileSize as "... the number of bytes of the media object. It is an optional attribute."

But this modification made rome more useful for me. So it depends on how badly you want to enforce the standard i guess :)