### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/rome-fetcher/src/main/java/com/rometools/fetcher/impl/ResponseHandler.java
+++ b/rome-fetcher/src/main/java/com/rometools/fetcher/impl/ResponseHandler.java
@@ -32,6 +32,9 @@ public class ResponseHandler {
 
     private final static Pattern characterEncodingPattern = Pattern.compile("charset=([.[^; ]]*)");
 
+    private ResponseHandler() {
+    }
+
     public static String getCharacterEncoding(final URLConnection connection) {
         return getCharacterEncoding(connection.getContentType());
     }

--- a/rome-fetcher/src/test/java/com/rometools/fetcher/samples/FeedAggregator.java
+++ b/rome-fetcher/src/test/java/com/rometools/fetcher/samples/FeedAggregator.java
@@ -46,6 +46,9 @@ import com.rometools.rome.io.SyndFeedOutput;
  */
 public class FeedAggregator {
 
+    private FeedAggregator() {
+    }
+
     public static void main(final String[] args) {
 
         boolean ok = false;

--- a/rome-fetcher/src/test/java/com/rometools/fetcher/samples/FeedReader.java
+++ b/rome-fetcher/src/test/java/com/rometools/fetcher/samples/FeedReader.java
@@ -37,6 +37,9 @@ import com.rometools.rome.feed.synd.SyndFeed;
  */
 public class FeedReader {
 
+    private FeedReader() {
+    }
+
     public static void main(final String[] args) {
 
         boolean ok = false;

--- a/rome-modules/src/main/java/com/rometools/modules/georss/GeoRSSUtils.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/GeoRSSUtils.java
@@ -28,6 +28,9 @@ import com.rometools.rome.feed.synd.SyndFeed;
  */
 public class GeoRSSUtils {
 
+    private GeoRSSUtils() {
+    }
+
     /**
      * This convenience method checks whether there is any geoRss Element and will return it (georss
      * simple or W3GGeo).

--- a/rome-propono/src/main/java/com/rometools/propono/atom/client/AtomClientFactory.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/client/AtomClientFactory.java
@@ -28,6 +28,9 @@ public class AtomClientFactory {
         Atom10Parser.setResolveURIs(true);
     }
 
+    private AtomClientFactory() {
+    }
+
     /**
      * Create AtomService by reading service doc from Atom Server.
      */

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/FactoryFinder.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/FactoryFinder.java
@@ -32,6 +32,9 @@ class FactoryFinder {
     private static SecuritySupport ss = new SecuritySupport();
     private static boolean firstTime = true;
 
+    private FactoryFinder() {
+    }
+
     private static void dPrint(final String msg) {
         if (debug) {
             System.err.println("Propono: " + msg);

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/BlogConnectionFactory.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/BlogConnectionFactory.java
@@ -31,6 +31,9 @@ public class BlogConnectionFactory {
 
     private static String METAWEBLOG_IMPL_CLASS = "com.rometools.propono.blogclient.metaweblog.MetaWeblogConnection";
 
+    private BlogConnectionFactory() {
+    }
+
     /**
      * Create a connection to a blog server.
      *

--- a/rome/src/main/java/com/rometools/rome/feed/impl/BeanIntrospector.java
+++ b/rome/src/main/java/com/rometools/rome/feed/impl/BeanIntrospector.java
@@ -44,6 +44,9 @@ public class BeanIntrospector {
     private static final String GETTER = "get";
     private static final String BOOLEAN_GETTER = "is";
 
+    private BeanIntrospector() {
+    }
+
     /**
      * Extract all {@link PropertyDescriptor}s for properties with getters and setters for the given
      * class.

--- a/rome/src/main/java/com/rometools/rome/feed/module/impl/ModuleUtils.java
+++ b/rome/src/main/java/com/rometools/rome/feed/module/impl/ModuleUtils.java
@@ -30,6 +30,9 @@ public class ModuleUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(ModuleUtils.class);
 
+    private ModuleUtils() {
+    }
+
     public static List<Module> cloneModules(final List<Module> modules) {
         List<Module> cModules = null;
         if (modules != null) {

--- a/rome/src/main/java/com/rometools/rome/feed/synd/impl/URINormalizer.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/impl/URINormalizer.java
@@ -8,6 +8,9 @@ package com.rometools.rome.feed.synd.impl;
  */
 public class URINormalizer {
 
+    private URINormalizer() {
+    }
+
     /**
      * Normalizes an URI as specified in RFC 2396bis.
      * <p>


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.