### PR TITLE
equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/rome-modules/src/main/java/com/rometools/modules/base/CustomTagImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/base/CustomTagImpl.java
@@ -145,6 +145,13 @@ public class CustomTagImpl implements CustomTag {
         return false;
     }
 
+    @Override
+    public int hashCode() {
+        int result = this.value != null ? this.value.hashCode() : 0;
+        result = 31 * result + (this.name != null ? this.name.hashCode() : 0);
+        return result;
+    }
+
     /**
      * Creates and returns a copy of this object. The precise meaning of "copy" may depend on the
      * class of the object. The general intent is that, for any object <tt>x</tt>, the expression:
@@ -241,6 +248,11 @@ public class CustomTagImpl implements CustomTag {
             } else {
                 return false;
             }
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value != null ? this.value.hashCode() : 0;
         }
     }
 }

--- a/rome-modules/src/main/java/com/rometools/modules/base/GoogleBaseImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/base/GoogleBaseImpl.java
@@ -36,6 +36,7 @@ package com.rometools.modules.base;
 
 import java.lang.reflect.Array;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Date;
 
 import org.slf4j.Logger;
@@ -1410,6 +1411,103 @@ public class GoogleBaseImpl implements GoogleBase {
         final EqualsBean eBean = new EqualsBean(this.getClass(), this);
 
         return eBean.beanEquals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = this.listingType != null ? this.listingType.hashCode() : 0;
+        result = 31 * result + (this.pickup != null ? this.pickup.hashCode() : 0);
+        result = 31 * result + (this.currency != null ? this.currency.hashCode() : 0);
+        result = 31 * result + (this.expirationDateTime != null ? this.expirationDateTime.hashCode() : 0);
+        result = 31 * result + (this.courseDateRange != null ? this.courseDateRange.hashCode() : 0);
+        result = 31 * result + (this.eventDateRange != null ? this.eventDateRange.hashCode() : 0);
+        result = 31 * result + (this.travelDateRange != null ? this.travelDateRange.hashCode() : 0);
+        result = 31 * result + (this.bathrooms != null ? this.bathrooms.hashCode() : 0);
+        result = 31 * result + (this.hoaDues != null ? this.hoaDues.hashCode() : 0);
+        result = 31 * result + (this.rating != null ? this.rating.hashCode() : 0);
+        result = 31 * result + (this.salary != null ? this.salary.hashCode() : 0);
+        result = 31 * result + (this.taxPercent != null ? this.taxPercent.hashCode() : 0);
+        result = 31 * result + (this.deliveryRadius != null ? this.deliveryRadius.hashCode() : 0);
+        result = 31 * result + (this.megapixels != null ? this.megapixels.hashCode() : 0);
+        result = 31 * result + (this.memory != null ? this.memory.hashCode() : 0);
+        result = 31 * result + (this.price != null ? this.price.hashCode() : 0);
+        result = 31 * result + (this.processorSpeed != null ? this.processorSpeed.hashCode() : 0);
+        result = 31 * result + (this.weight != null ? this.weight.hashCode() : 0);
+        result = 31 * result + (this.gender != null ? this.gender.hashCode() : 0);
+        result = 31 * result + (this.area != null ? this.area.hashCode() : 0);
+        result = 31 * result + (this.age != null ? this.age.hashCode() : 0);
+        result = 31 * result + (this.bedrooms != null ? this.bedrooms.hashCode() : 0);
+        result = 31 * result + (this.mileage != null ? this.mileage.hashCode() : 0);
+        result = 31 * result + (this.pages != null ? this.pages.hashCode() : 0);
+        result = 31 * result + (this.quantity != null ? this.quantity.hashCode() : 0);
+        result = 31 * result + (this.fromLocation != null ? this.fromLocation.hashCode() : 0);
+        result = 31 * result + (this.location != null ? this.location.hashCode() : 0);
+        result = 31 * result + (this.toLocation != null ? this.toLocation.hashCode() : 0);
+        result = 31 * result + (this.priceType != null ? this.priceType.hashCode() : 0);
+        result = 31 * result + (this.salaryType != null ? this.salaryType.hashCode() : 0);
+        result = 31 * result + (this.expirationDate != null ? this.expirationDate.hashCode() : 0);
+        result = 31 * result + (this.publishDate != null ? this.publishDate.hashCode() : 0);
+        result = 31 * result + (this.size != null ? this.size.hashCode() : 0);
+        result = 31 * result + (this.SexualOrientation != null ? this.SexualOrientation.hashCode() : 0);
+        result = 31 * result + (this.apparelType != null ? this.apparelType.hashCode() : 0);
+        result = 31 * result + (this.brand != null ? this.brand.hashCode() : 0);
+        result = 31 * result + (this.condition != null ? this.condition.hashCode() : 0);
+        result = 31 * result + (this.courseNumber != null ? this.courseNumber.hashCode() : 0);
+        result = 31 * result + (this.courseTimes != null ? this.courseTimes.hashCode() : 0);
+        result = 31 * result + (this.deliveryNotes != null ? this.deliveryNotes.hashCode() : 0);
+        result = 31 * result + (this.education != null ? this.education.hashCode() : 0);
+        result = 31 * result + (this.employer != null ? this.employer.hashCode() : 0);
+        result = 31 * result + (this.id != null ? this.id.hashCode() : 0);
+        result = 31 * result + (this.immigrationStatus != null ? this.immigrationStatus.hashCode() : 0);
+        result = 31 * result + (this.isbn != null ? this.isbn.hashCode() : 0);
+        result = 31 * result + (this.make != null ? this.make.hashCode() : 0);
+        result = 31 * result + (this.manufacturer != null ? this.manufacturer.hashCode() : 0);
+        result = 31 * result + (this.manufacturerId != null ? this.manufacturerId.hashCode() : 0);
+        result = 31 * result + (this.maritalStatus != null ? this.maritalStatus.hashCode() : 0);
+        result = 31 * result + (this.model != null ? this.model.hashCode() : 0);
+        result = 31 * result + (this.modelNumber != null ? this.modelNumber.hashCode() : 0);
+        result = 31 * result + (this.nameOfItemBeingReviewed != null ? this.nameOfItemBeingReviewed.hashCode() : 0);
+        result = 31 * result + (this.newsSource != null ? this.newsSource.hashCode() : 0);
+        result = 31 * result + (this.occupation != null ? this.occupation.hashCode() : 0);
+        result = 31 * result + (this.operatingSystems != null ? this.operatingSystems.hashCode() : 0);
+        result = 31 * result + (this.paymentNotes != null ? this.paymentNotes.hashCode() : 0);
+        result = 31 * result + (this.publicationName != null ? this.publicationName.hashCode() : 0);
+        result = 31 * result + (this.publicationVolume != null ? this.publicationVolume.hashCode() : 0);
+        result = 31 * result + (this.reviewType != null ? this.reviewType.hashCode() : 0);
+        result = 31 * result + (this.reviewerType != null ? this.reviewerType.hashCode() : 0);
+        result = 31 * result + (this.schoolDistrict != null ? this.schoolDistrict.hashCode() : 0);
+        result = 31 * result + (this.serviceType != null ? this.serviceType.hashCode() : 0);
+        result = 31 * result + (this.taxRegion != null ? this.taxRegion.hashCode() : 0);
+        result = 31 * result + (this.university != null ? this.university.hashCode() : 0);
+        result = 31 * result + (this.upc != null ? this.upc.hashCode() : 0);
+        result = 31 * result + (this.vehicleType != null ? this.vehicleType.hashCode() : 0);
+        result = 31 * result + (this.vin != null ? this.vin.hashCode() : 0);
+        result = 31 * result + (this.urlOfItemBeingReviewed != null ? this.urlOfItemBeingReviewed.hashCode() : 0);
+        result = 31 * result + (this.year != null ? this.year.hashCode() : 0);
+        result = 31 * result + Arrays.hashCode(this.actors);
+        result = 31 * result + Arrays.hashCode(this.agents);
+        result = 31 * result + Arrays.hashCode(this.artists);
+        result = 31 * result + Arrays.hashCode(this.authors);
+        result = 31 * result + Arrays.hashCode(this.color);
+        result = 31 * result + Arrays.hashCode(this.ethnicities);
+        result = 31 * result + Arrays.hashCode(this.format);
+        result = 31 * result + Arrays.hashCode(this.imageLinks);
+        result = 31 * result + Arrays.hashCode(this.interestedIn);
+        result = 31 * result + Arrays.hashCode(this.jobFunctions);
+        result = 31 * result + Arrays.hashCode(this.jobIndustries);
+        result = 31 * result + Arrays.hashCode(this.jobTypes);
+        result = 31 * result + Arrays.hashCode(this.labels);
+        result = 31 * result + Arrays.hashCode(this.licenses);
+        result = 31 * result + Arrays.hashCode(this.paymentAccepted);
+        result = 31 * result + Arrays.hashCode(this.productTypes);
+        result = 31 * result + Arrays.hashCode(this.programmingLanguages);
+        result = 31 * result + Arrays.hashCode(this.propertyTypes);
+        result = 31 * result + Arrays.hashCode(this.relatedLinks);
+        result = 31 * result + Arrays.hashCode(this.shipping);
+        result = 31 * result + Arrays.hashCode(this.squareFootages);
+        result = 31 * result + Arrays.hashCode(this.subjectAreas);
+        result = 31 * result + Arrays.hashCode(this.subjects);
+        return result;
     }
 
     private Object arrayCopy(final Object[] source) {

--- a/rome-modules/src/main/java/com/rometools/modules/base/types/DateTimeRange.java
+++ b/rome-modules/src/main/java/com/rometools/modules/base/types/DateTimeRange.java
@@ -133,4 +133,11 @@ public class DateTimeRange implements CloneableType {
         }
         return true;
     }
+
+    @Override
+    public int hashCode() {
+        int result = this.end != null ? this.end.hashCode() : 0;
+        result = 31 * result + (this.start != null ? this.start.hashCode() : 0);
+        return result;
+    }
 }

--- a/rome-modules/src/main/java/com/rometools/modules/base/types/FloatUnit.java
+++ b/rome-modules/src/main/java/com/rometools/modules/base/types/FloatUnit.java
@@ -166,4 +166,11 @@ public class FloatUnit implements CloneableType {
         }
         return false;
     }
+
+    @Override
+    public int hashCode() {
+        int result = this.units != null ? this.units.hashCode() : 0;
+        result = 31 * result + (this.value != +0.0f ? Float.floatToIntBits(this.value) : 0);
+        return result;
+    }
 }

--- a/rome-modules/src/main/java/com/rometools/modules/base/types/IntUnit.java
+++ b/rome-modules/src/main/java/com/rometools/modules/base/types/IntUnit.java
@@ -121,4 +121,11 @@ public class IntUnit implements CloneableType {
         }
         return false;
     }
+
+    @Override
+    public int hashCode() {
+        int result = this.units != null ? this.units.hashCode() : 0;
+        result = 31 * result + this.value;
+        return result;
+    }
 }

--- a/rome-modules/src/main/java/com/rometools/modules/base/types/ShippingType.java
+++ b/rome-modules/src/main/java/com/rometools/modules/base/types/ShippingType.java
@@ -132,6 +132,14 @@ public class ShippingType implements CloneableType {
         return false;
     }
 
+    @Override
+    public int hashCode() {
+        int result = this.price != null ? this.price.hashCode() : 0;
+        result = 31 * result + (this.service != null ? this.service.hashCode() : 0);
+        result = 31 * result + (this.country != null ? this.country.hashCode() : 0);
+        return result;
+    }
+
     /**
      * Enumeration class of valid options for ServiceType.
      */

--- a/rome-modules/src/main/java/com/rometools/modules/base/types/Size.java
+++ b/rome-modules/src/main/java/com/rometools/modules/base/types/Size.java
@@ -165,4 +165,12 @@ public class Size implements CloneableType {
         }
         return false;
     }
+
+    @Override
+    public int hashCode() {
+        int result = this.height != null ? this.height.hashCode() : 0;
+        result = 31 * result + (this.length != null ? this.length.hashCode() : 0);
+        result = 31 * result + (this.width != null ? this.width.hashCode() : 0);
+        return result;
+    }
 }

--- a/rome-modules/src/main/java/com/rometools/modules/base/types/YearType.java
+++ b/rome-modules/src/main/java/com/rometools/modules/base/types/YearType.java
@@ -104,4 +104,9 @@ public class YearType implements CloneableType {
         }
         return false;
     }
+
+    @Override
+    public int hashCode() {
+        return this.year;
+    }
 }

--- a/rome-modules/src/main/java/com/rometools/modules/cc/CreativeCommonsImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/cc/CreativeCommonsImpl.java
@@ -41,6 +41,7 @@
 package com.rometools.modules.cc;
 
 import java.lang.reflect.Array;
+import java.util.Arrays;
 
 import com.rometools.modules.cc.types.License;
 import com.rometools.rome.feed.CopyFrom;
@@ -115,6 +116,13 @@ public class CreativeCommonsImpl implements CreativeCommons {
         final EqualsBean eBean = new EqualsBean(this.getClass(), this);
 
         return eBean.beanEquals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(this.allLicenses);
+        result = 31 * result + Arrays.hashCode(this.licenses);
+        return result;
     }
 
     @Override

--- a/rome-modules/src/main/java/com/rometools/modules/georss/geometries/LineString.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/geometries/LineString.java
@@ -59,6 +59,11 @@ public final class LineString extends AbstractCurve {
         return getPositionList().equals(((LineString) obj).getPositionList());
     }
 
+    @Override
+    public int hashCode() {
+        return this.posList != null ? this.posList.hashCode() : 0;
+    }
+
     /**
      * Get the position list
      *

--- a/rome-modules/src/main/java/com/rometools/modules/georss/geometries/LinearRing.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/geometries/LinearRing.java
@@ -56,6 +56,11 @@ public final class LinearRing extends AbstractRing {
         return getPositionList().equals(((LinearRing) obj).getPositionList());
     }
 
+    @Override
+    public int hashCode() {
+        return this.posList != null ? this.posList.hashCode() : 0;
+    }
+
     /**
      * Get the position list
      *

--- a/rome-modules/src/main/java/com/rometools/modules/georss/geometries/Point.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/geometries/Point.java
@@ -56,6 +56,11 @@ public final class Point extends AbstractGeometricPrimitive {
         return getPosition().equals(((Point) obj).getPosition());
     }
 
+    @Override
+    public int hashCode() {
+        return this.pos != null ? this.pos.hashCode() : 0;
+    }
+
     /**
      * Get the position
      *

--- a/rome-modules/src/main/java/com/rometools/modules/georss/geometries/Polygon.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/geometries/Polygon.java
@@ -87,6 +87,13 @@ public final class Polygon extends AbstractSurface implements Cloneable {
         return true;
     }
 
+    @Override
+    public int hashCode() {
+        int result = this.exterior != null ? this.exterior.hashCode() : 0;
+        result = 31 * result + (this.interior != null ? this.interior.hashCode() : 0);
+        return result;
+    }
+
     /**
      * Retrieve the outer border
      *

--- a/rome-modules/src/main/java/com/rometools/modules/georss/geometries/Position.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/geometries/Position.java
@@ -65,6 +65,17 @@ public class Position implements Cloneable, Serializable {
         return p.latitude == latitude && p.longitude == longitude;
     }
 
+    @Override
+    public int hashCode() {
+        int result;
+        long temp;
+        temp = Double.doubleToLongBits(this.latitude);
+        result = (int) (temp ^ temp >>> 32);
+        temp = Double.doubleToLongBits(this.longitude);
+        result = 31 * result + (int) (temp ^ temp >>> 32);
+        return result;
+    }
+
     /**
      * @return latitude
      */

--- a/rome-modules/src/main/java/com/rometools/modules/georss/geometries/PositionList.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/geometries/PositionList.java
@@ -16,6 +16,7 @@
 package com.rometools.modules.georss.geometries;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 /**
  * A list of geographic positions, latitude, longitude decimal degrees WGS84
@@ -68,6 +69,14 @@ public class PositionList implements Cloneable, Serializable {
             }
         }
         return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(this.latitude);
+        result = 31 * result + Arrays.hashCode(this.longitude);
+        result = 31 * result + this.size;
+        return result;
     }
 
     private void ensureCapacity(int new_size) {

--- a/rome-modules/src/main/java/com/rometools/modules/slash/SlashImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/slash/SlashImpl.java
@@ -44,6 +44,8 @@ package com.rometools.modules.slash;
 import com.rometools.rome.feed.CopyFrom;
 import com.rometools.rome.feed.impl.EqualsBean;
 
+import java.util.Arrays;
+
 /**
  * @version $Revision: 1.2 $
  * @author <a href="mailto:cooper@screaming-penguin.com">Robert "kebernet" Cooper</a>
@@ -142,4 +144,12 @@ public class SlashImpl implements Slash {
         return eBean.beanEquals(obj);
     }
 
+    @Override
+    public int hashCode() {
+        int result = this.section != null ? this.section.hashCode() : 0;
+        result = 31 * result + (this.department != null ? this.department.hashCode() : 0);
+        result = 31 * result + (this.comments != null ? this.comments.hashCode() : 0);
+        result = 31 * result + Arrays.hashCode(this.hitParade);
+        return result;
+    }
 }

--- a/rome-propono/src/main/java/com/rometools/propono/atom/client/ClientEntry.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/client/ClientEntry.java
@@ -126,6 +126,15 @@ public class ClientEntry extends Entry {
         return false;
     }
 
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (this.service != null ? this.service.hashCode() : 0);
+        result = 31 * result + (this.collection != null ? this.collection.hashCode() : 0);
+        result = 31 * result + (this.partial ? 1 : 0);
+        return result;
+    }
+
     /**
      * Update entry by posting new representation of entry to server. Note that you should not
      * attempt to update entries that you get from iterating over a collection they may be "partial"

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/BlogEntry.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/BlogEntry.java
@@ -222,6 +222,14 @@ public interface BlogEntry {
             return false;
         }
 
+        @Override
+        public int hashCode() {
+            int result = this.id != null ? this.id.hashCode() : 0;
+            result = 31 * result + (this.name != null ? this.name.hashCode() : 0);
+            result = 31 * result + (this.url != null ? this.url.hashCode() : 0);
+            return result;
+        }
+
         /** Get category id */
         public String getId() {
             return id;

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/atomprotocol/AtomEntry.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/atomprotocol/AtomEntry.java
@@ -84,6 +84,13 @@ public class AtomEntry extends BaseBlogEntry implements BlogEntry {
     }
 
     @Override
+    public int hashCode() {
+        int result = this.editURI != null ? this.editURI.hashCode() : 0;
+        result = 31 * result + (this.collection != null ? this.collection.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public void save() throws BlogClientException {
         final boolean create = getToken() == null;
         if (create && getCollection() == null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1206 - “equals(Object obj)" and "hashCode()" should be overridden in pairs ”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1206
Please let me know if you have any questions.
Ayman Abdelghany.
