### PR TITLE
Null pointers should not be dereferenced

### DIFF
--- a/rome-modules/src/main/java/com/rometools/modules/georss/geometries/LineString.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/geometries/LineString.java
@@ -50,6 +50,10 @@ public final class LineString extends AbstractCurve {
 
     @Override
     public boolean equals(final Object obj) {
+        if(obj == null) {
+            return false;
+        }
+        
         if (this == obj) {
             return true;
         }

--- a/rome-modules/src/main/java/com/rometools/modules/georss/geometries/LinearRing.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/geometries/LinearRing.java
@@ -47,6 +47,10 @@ public final class LinearRing extends AbstractRing {
 
     @Override
     public boolean equals(final Object obj) {
+        if(obj == null) {
+            return false;
+        }
+        
         if (this == obj) {
             return true;
         }

--- a/rome-modules/src/main/java/com/rometools/modules/georss/geometries/Point.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/geometries/Point.java
@@ -47,6 +47,10 @@ public final class Point extends AbstractGeometricPrimitive {
 
     @Override
     public boolean equals(final Object obj) {
+        if(obj == null) {
+            return false;
+        }
+        
         if (this == obj) {
             return true;
         }

--- a/rome-modules/src/main/java/com/rometools/modules/georss/geometries/Polygon.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/geometries/Polygon.java
@@ -56,6 +56,10 @@ public final class Polygon extends AbstractSurface implements Cloneable {
 
     @Override
     public boolean equals(final Object obj) {
+        if(obj == null) {
+            return false;
+        }
+        
         if (this == obj) {
             return true;
         }

--- a/rome-modules/src/main/java/com/rometools/modules/georss/geometries/Position.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/geometries/Position.java
@@ -54,6 +54,10 @@ public class Position implements Cloneable, Serializable {
 
     @Override
     public boolean equals(final Object obj) {
+        if(obj == null) {
+            return false;
+        }
+        
         if (this == obj) {
             return true;
         }

--- a/rome-modules/src/main/java/com/rometools/modules/georss/geometries/PositionList.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/geometries/PositionList.java
@@ -51,6 +51,10 @@ public class PositionList implements Cloneable, Serializable {
 
     @Override
     public boolean equals(final Object obj) {
+        if(obj == null) {
+            return false;
+        }
+        
         if (this == obj) {
             return true;
         }

--- a/rome-modules/src/main/java/com/rometools/modules/photocast/types/PhotoDate.java
+++ b/rome-modules/src/main/java/com/rometools/modules/photocast/types/PhotoDate.java
@@ -103,6 +103,10 @@ public class PhotoDate extends Date {
 
     @Override
     public boolean equals(final Object o) {
+        if(o == null) {
+            return false;
+        }
+
         if (o instanceof Date || ((Date) o).getTime() / 1000 == getTime() / 1000) {
             return true;
         } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2259 - “Null pointers should not be dereferenced”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259
Please let me know if you have any questions.
Ayman Abdelghany.
