### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/rome-fetcher/src/main/java/com/rometools/fetcher/impl/DiskFeedInfoCache.java
+++ b/rome-fetcher/src/main/java/com/rometools/fetcher/impl/DiskFeedInfoCache.java
@@ -144,7 +144,7 @@ public class DiskFeedInfoCache implements FeedFetcherCache {
     }
 
     private static String replaceNonAlphanumeric(final String string, final char character) {
-        final StringBuffer buffer = new StringBuffer(string.length());
+        final StringBuilder buffer = new StringBuilder(string.length());
         for (final char singleChar : string.toCharArray()) {
             if (Character.isLetterOrDigit(singleChar)) {
                 buffer.append(singleChar);

--- a/rome-modules/src/main/java/com/rometools/modules/base/io/GoogleBaseParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/base/io/GoogleBaseParser.java
@@ -146,7 +146,7 @@ public class GoogleBaseParser implements ModuleParser {
     }
 
     public static String stripNonValidCharacters(final char[] validCharacters, final String input) {
-        final StringBuffer newString = new StringBuffer();
+        final StringBuilder newString = new StringBuilder();
 
         for (int i = 0; i < input.length(); i++) {
             for (final char validCharacter : validCharacters) {

--- a/rome-modules/src/main/java/com/rometools/modules/content/io/ContentModuleParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/content/io/ContentModuleParser.java
@@ -153,7 +153,7 @@ public class ContentModuleParser implements com.rometools.rome.io.ModuleParser {
     }
 
     protected String getXmlInnerText(final Element e) {
-        final StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
         final XMLOutputter xo = new XMLOutputter();
         final List<Content> children = e.getContent();
         sb.append(xo.outputString(children));

--- a/rome-modules/src/main/java/com/rometools/modules/georss/GMLGenerator.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/GMLGenerator.java
@@ -56,7 +56,7 @@ public class GMLGenerator implements ModuleGenerator {
 
     private Element createPosListElement(final PositionList posList) {
         final Element posElement = new Element("posList", GeoRSSModule.GML_NS);
-        final StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
         for (int i = 0; i < posList.size(); ++i) {
             sb.append(posList.getLatitude(i)).append(" ").append(posList.getLongitude(i)).append(" ");
         }

--- a/rome-modules/src/main/java/com/rometools/modules/georss/SimpleGenerator.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/SimpleGenerator.java
@@ -59,7 +59,7 @@ public class SimpleGenerator implements ModuleGenerator {
      * @return String representation
      */
     private String posListToString(final PositionList posList) {
-        final StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
         for (int i = 0; i < posList.size(); ++i) {
             sb.append(posList.getLatitude(i)).append(" ").append(posList.getLongitude(i)).append(" ");
         }

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/AbstractITunesObject.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/AbstractITunesObject.java
@@ -245,7 +245,7 @@ public abstract class AbstractITunesObject implements ITunes, java.lang.Cloneabl
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("[");
+        final StringBuilder sb = new StringBuilder("[");
         sb.append(" Author: ");
         sb.append(getAuthor());
         sb.append(" Block: ");

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformationImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformationImpl.java
@@ -163,7 +163,7 @@ public class EntryInformationImpl extends AbstractITunesObject implements EntryI
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("[");
+        final StringBuilder sb = new StringBuilder("[");
         sb.append(" duration: ");
         sb.append(getDuration());
         sb.append(" closedCaptioned: ");

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/FeedInformationImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/FeedInformationImpl.java
@@ -209,7 +209,7 @@ public class FeedInformationImpl extends AbstractITunesObject implements FeedInf
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("[");
+        final StringBuilder sb = new StringBuilder("[");
         sb.append(" email: ");
         sb.append(getOwnerEmailAddress());
         sb.append(" name: ");

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesGenerator.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesGenerator.java
@@ -156,7 +156,7 @@ public class ITunesGenerator implements ModuleGenerator {
         }
 
         if (itunes.getKeywords() != null) {
-            final StringBuffer sb = new StringBuffer();
+            final StringBuilder sb = new StringBuilder();
 
             for (int i = 0; i < itunes.getKeywords().length; i++) {
                 if (i != 0) {

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
@@ -225,7 +225,7 @@ public class ITunesParser implements ModuleParser {
     }
 
     protected String getXmlInnerText(final Element e) {
-        final StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
         final XMLOutputter xo = new XMLOutputter();
         final List<Content> children = e.getContent();
         sb.append(xo.outputString(children));

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/types/Category.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/types/Category.java
@@ -125,7 +125,7 @@ public class Category implements Serializable {
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer(getName());
+        final StringBuilder sb = new StringBuilder(getName());
 
         if (getSubcategory() != null) {
             sb.append(" -> " + getSubcategory().toString());

--- a/rome-modules/src/main/java/com/rometools/modules/slash/io/SlashModuleGenerator.java
+++ b/rome-modules/src/main/java/com/rometools/modules/slash/io/SlashModuleGenerator.java
@@ -80,7 +80,7 @@ public class SlashModuleGenerator implements ModuleGenerator {
             element.addContent(generateSimpleElement("section", slash.getSection()));
         }
         if (slash.getHitParade() != null && slash.getHitParade().length > 0) {
-            final StringBuffer buff = new StringBuffer();
+            final StringBuilder buff = new StringBuilder();
             final Integer[] p = slash.getHitParade();
             for (int i = 0; i < p.length; i++) {
                 if (i != 0) {

--- a/rome-opml/src/main/java/com/rometools/opml/feed/synd/impl/ConverterForOPML10.java
+++ b/rome-opml/src/main/java/com/rometools/opml/feed/synd/impl/ConverterForOPML10.java
@@ -210,7 +210,7 @@ public class ConverterForOPML10 implements Converter {
 
             final List<SyndCategory> cats = Collections.synchronizedList(entry.getCategories());
             boolean parentFound = false;
-            final StringBuffer category = new StringBuffer();
+            final StringBuilder category = new StringBuilder();
 
             for (int j = 0; j < cats.size(); j++) {
                 final SyndCategory cat = cats.get(j);

--- a/rome-opml/src/main/java/com/rometools/opml/feed/synd/impl/TreeCategoryImpl.java
+++ b/rome-opml/src/main/java/com/rometools/opml/feed/synd/impl/TreeCategoryImpl.java
@@ -12,6 +12,10 @@ public class TreeCategoryImpl extends SyndCategoryImpl {
 
     @Override
     public boolean equals(final Object o) {
+        if(o == null) {
+            return false;
+        }
+        
         final SyndCategory c = (SyndCategory) o;
         if (c.getTaxonomyUri() != null && c.getTaxonomyUri().equals(getTaxonomyUri())) {
             return true;

--- a/rome-opml/src/main/java/com/rometools/opml/io/impl/OPML10Generator.java
+++ b/rome-opml/src/main/java/com/rometools/opml/io/impl/OPML10Generator.java
@@ -173,7 +173,7 @@ public class OPML10Generator extends BaseWireFeedGenerator implements WireFeedGe
             return null;
         }
 
-        final StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
         sb.append(value[0]);
 
         for (int i = 1; i < value.length; i++) {

--- a/rome-propono/src/main/java/com/rometools/propono/utils/Utilities.java
+++ b/rome-propono/src/main/java/com/rometools/propono/utils/Utilities.java
@@ -83,7 +83,7 @@ public final class Utilities {
      * Read input from stream and into string.
      */
     public static String streamToString(final InputStream is) throws IOException {
-        final StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
         final BufferedReader in = new BufferedReader(new InputStreamReader(is));
         String line;
         while ((line = in.readLine()) != null) {
@@ -119,7 +119,7 @@ public final class Utilities {
      * Replaces occurences of non-alphanumeric characters with a supplied char.
      */
     public static String replaceNonAlphanumeric(final String str, final char subst) {
-        final StringBuffer ret = new StringBuffer(str.length());
+        final StringBuilder ret = new StringBuilder(str.length());
         final char[] testChars = str.toCharArray();
         for (final char testChar : testChars) {
             if (Character.isLetterOrDigit(testChar)) {

--- a/rome/src/main/java/com/rometools/rome/feed/impl/ToStringBean.java
+++ b/rome/src/main/java/com/rometools/rome/feed/impl/ToStringBean.java
@@ -145,7 +145,7 @@ public class ToStringBean implements Serializable {
      */
     private String toString(final String prefix) {
 
-        final StringBuffer sb = new StringBuffer(128);
+        final StringBuilder sb = new StringBuilder(128);
 
         try {
 

--- a/rome/src/main/java/com/rometools/rome/io/impl/Atom03Generator.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/Atom03Generator.java
@@ -368,7 +368,7 @@ public class Atom03Generator extends BaseWireFeedGenerator {
 
             } else if (mode.equals(Content.XML)) {
 
-                final StringBuffer tmpDocString = new StringBuffer("<tmpdoc>");
+                final StringBuilder tmpDocString = new StringBuilder("<tmpdoc>");
                 tmpDocString.append(value);
                 tmpDocString.append("</tmpdoc>");
                 final StringReader tmpDocReader = new StringReader(tmpDocString.toString());

--- a/rome/src/main/java/com/rometools/rome/io/impl/Atom10Generator.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/Atom10Generator.java
@@ -478,7 +478,7 @@ public class Atom10Generator extends BaseWireFeedGenerator {
 
             if (atomType != null && (atomType.equals(Content.XHTML) || atomType.indexOf("/xml") != -1 || atomType.indexOf("+xml") != -1)) {
 
-                final StringBuffer tmpDocString = new StringBuffer("<tmpdoc>");
+                final StringBuilder tmpDocString = new StringBuilder("<tmpdoc>");
                 tmpDocString.append(value);
                 tmpDocString.append("</tmpdoc>");
                 final StringReader tmpDocReader = new StringReader(tmpDocString.toString());

--- a/rome/src/main/java/com/rometools/rome/io/impl/DateParser.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/DateParser.java
@@ -113,7 +113,7 @@ public class DateParser {
             try {
                 pp = new ParsePosition(0);
                 d = df.parse(sDate, pp);
-                if (pp.getIndex() != sDate.length()) {
+                if (sDate pp.getIndex() != sDate.length()) {
                     d = null;
                 }
                 // LOG.debug("pp["+pp.getIndex()+"] s["+sDate+" m["+masks[i]+"] d["+d+"]");

--- a/rome/src/main/java/com/rometools/rome/io/impl/DateParser.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/DateParser.java
@@ -113,7 +113,7 @@ public class DateParser {
             try {
                 pp = new ParsePosition(0);
                 d = df.parse(sDate, pp);
-                if (sDate pp.getIndex() != sDate.length()) {
+                if (pp.getIndex() != sDate.length()) {
                     d = null;
                 }
                 // LOG.debug("pp["+pp.getIndex()+"] s["+sDate+" m["+masks[i]+"] d["+d+"]");

--- a/rome/src/main/java/com/rometools/rome/io/impl/XmlFixerReader.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/XmlFixerReader.java
@@ -664,7 +664,7 @@ public class XmlFixerReader extends Reader {
         if (s.indexOf('&') == -1) {
             return s;
         }
-        final StringBuffer sb = new StringBuffer(s.length());
+        final StringBuilder sb = new StringBuilder(s.length());
         int pos = 0;
         while (pos < s.length()) {
             String chunck = s.substring(pos);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.
