### PR TITLE
Catch itunes duration parsing exceptions

### DIFF
--- a/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
@@ -147,8 +147,12 @@ public class ITunesParser implements ModuleParser {
             final Element duration = element.getChild("duration", ns);
 
             if (duration != null && duration.getValue() != null) {
-                final Duration dur = new Duration(duration.getValue().trim());
-                entryInfo.setDuration(dur);
+                try {
+                    final Duration dur = new Duration(duration.getValue().trim());
+                    entryInfo.setDuration(dur);
+                } catch (Exception e) {
+                    LOG.warn("Failed to parse duration: {}", duration.getValue());
+                }
             }
 
             final Element closedCaptioned = element.getChild("isClosedCaptioned", ns);
@@ -216,7 +220,7 @@ public class ITunesParser implements ModuleParser {
                     final URL imageURL = new URL(image.getAttributeValue("href").trim());
                     module.setImage(imageURL);
                 } catch (final MalformedURLException e) {
-                    LOG.debug("Malformed URL Exception reading itunes:image tag: {}", image.getAttributeValue("href"));
+                    LOG.warn("Malformed URL Exception reading itunes:image tag: {}", image.getAttributeValue("href"));
                 }
             }
         }

--- a/rome-modules/src/test/java/com/rometools/modules/itunes/ITunesParserTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/itunes/ITunesParserTest.java
@@ -34,6 +34,7 @@ import com.rometools.modules.itunes.AbstractITunesObject;
 import com.rometools.modules.itunes.EntryInformationImpl;
 import com.rometools.modules.itunes.FeedInformationImpl;
 import com.rometools.modules.itunes.io.ITunesGenerator;
+import com.rometools.modules.itunes.types.Duration;
 import com.rometools.rome.feed.module.Module;
 import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
@@ -132,5 +133,29 @@ public class ITunesParserTest extends AbstractTestCase {
         assertEquals(true, entryInfo.getClosedCaptioned());
         assertEquals(Integer.valueOf(2), entryInfo.getOrder());
         assertEquals("http://example.org/image.png", entryInfo.getImage().toString());
+    }
+
+    public void testDuration() throws Exception {
+        SyndFeed feed = new SyndFeedInput().build(new XmlReader(getClass().getResource("duration.xml")));
+        SyndEntry entry = feed.getEntries().get(0);
+        EntryInformationImpl module = (EntryInformationImpl) entry.getModule(AbstractITunesObject.URI);
+
+        assertEquals(1000, module.getDuration().getMilliseconds());
+    }
+
+    public void testDurationEmpty() throws Exception {
+        SyndFeed feed = new SyndFeedInput().build(new XmlReader(getClass().getResource("duration-empty.xml")));
+        SyndEntry entry = feed.getEntries().get(0);
+        EntryInformationImpl module = (EntryInformationImpl) entry.getModule(AbstractITunesObject.URI);
+
+        assertNull(module.getDuration());
+    }
+
+    public void testDurationBad() throws Exception {
+        SyndFeed feed = new SyndFeedInput().build(new XmlReader(getClass().getResource("duration-bad.xml")));
+        SyndEntry entry = feed.getEntries().get(0);
+        EntryInformationImpl module = (EntryInformationImpl) entry.getModule(AbstractITunesObject.URI);
+
+        assertNull(module.getDuration());
     }
 }

--- a/rome-modules/src/test/resources/com/rometools/modules/itunes/duration-bad.xml
+++ b/rome-modules/src/test/resources/com/rometools/modules/itunes/duration-bad.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+    <channel>
+        <item>
+            <itunes:duration>00:00:00:01</itunes:duration>
+        </item>
+    </channel>
+</rss>

--- a/rome-modules/src/test/resources/com/rometools/modules/itunes/duration-empty.xml
+++ b/rome-modules/src/test/resources/com/rometools/modules/itunes/duration-empty.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+    <channel>
+        <item>
+            <itunes:duration/>
+        </item>
+    </channel>
+</rss>

--- a/rome-modules/src/test/resources/com/rometools/modules/itunes/duration.xml
+++ b/rome-modules/src/test/resources/com/rometools/modules/itunes/duration.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+    <channel>
+        <item>
+            <itunes:duration>00:00:01</itunes:duration>
+        </item>
+    </channel>
+</rss>


### PR DESCRIPTION
Parsing of a malformed or empty duration resulted in an uncaught
exception that was breaking feed parsing completely. We already catch
exceptions when parsing other fields, e.g. href attribute of the image
tag. Also, it's more user-friendly to handle malformed data instead of
failing everything.