### PR TITLE
removes the "SLF4J: Failed to load class"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,6 +327,11 @@
                 <version>1.7.16</version>
             </dependency>
             <dependency>
+  		<groupId>org.slf4j</groupId>
+  		<artifactId>slf4j-simple</artifactId>
+  		<version>1.7.16</version>
+  	    </dependency>
+            <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>1.1.3</version>


### PR DESCRIPTION
Without loading slf4j-simple, it throws:
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.