### PR TITLE
Do not set unsupported XML parser features

### DIFF
--- a/rome/src/main/java/com/rometools/rome/io/WireFeedInput.java
+++ b/rome/src/main/java/com/rometools/rome/io/WireFeedInput.java
@@ -359,23 +359,29 @@ public class WireFeedInput {
             }
 
         } catch (final JDOMException e) {
-            throw new IllegalStateException("JDOM could not create a SAX parser");
+            throw new IllegalStateException("JDOM could not create a SAX parser", e);
         }
         
         saxBuilder.setExpandEntities(false);
-        
+
         return saxBuilder;
-        
+
     }
     
     private void setFeature(SAXBuilder saxBuilder, XMLReader parser, String feature, boolean value) {
-        try {
+        if (isFeatureSupported(parser, feature, value)) {
             saxBuilder.setFeature(feature, value);
+        }
+    }
+
+    private boolean isFeatureSupported(XMLReader parser, String feature, boolean value) {
+        try {
             parser.setFeature(feature, value);
+            return true;
         } catch (final SAXNotRecognizedException e) {
-            // ignore
+            return false;
         } catch (final SAXNotSupportedException e) {
-            // ignore
+            return false;
         }
     }
 


### PR DESCRIPTION
Fixes bug introduced in 2bc58a0. The call to `XMLReader::setFeature`
is used to check if the feature is supported and must happen before
`SAXBuilder::setFeature`. Otherwise XML parsing throws an exception.

The change is not tested, because it is exceptionally cumbersome to
test unsupported features. Possible ways to do it include using an
existing XML library that is known to not support features that the
code is trying to set, or implementing a mock XML parser that doesn't
support any features at all. It's hard to include an XML library
without interfering with other tests and it's hard to implement a mock
XML parser.

Fixes #294