### PR TITLE
Deprecate all classes in certiorem and propono

### DIFF
--- a/rome-certiorem-webapp/src/main/java/com/rometools/certiorem/webapp/HubServlet.java
+++ b/rome-certiorem-webapp/src/main/java/com/rometools/certiorem/webapp/HubServlet.java
@@ -26,7 +26,9 @@ import com.rometools.certiorem.web.AbstractHubServlet;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 @Singleton
 public class HubServlet extends AbstractHubServlet {
 

--- a/rome-certiorem-webapp/src/main/java/com/rometools/certiorem/webapp/NotifyTest.java
+++ b/rome-certiorem-webapp/src/main/java/com/rometools/certiorem/webapp/NotifyTest.java
@@ -33,7 +33,9 @@ import com.rometools.certiorem.pub.Publisher;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 @Singleton
 public class NotifyTest extends HttpServlet {
 

--- a/rome-certiorem-webapp/src/main/java/com/rometools/certiorem/webapp/ServerModule.java
+++ b/rome-certiorem-webapp/src/main/java/com/rometools/certiorem/webapp/ServerModule.java
@@ -41,7 +41,9 @@ import com.rometools.fetcher.impl.HttpURLFeedFetcher;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class ServerModule extends GuiceServletContextListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(ServerModule.class);

--- a/rome-certiorem-webapp/src/main/java/com/rometools/certiorem/webapp/SubServlet.java
+++ b/rome-certiorem-webapp/src/main/java/com/rometools/certiorem/webapp/SubServlet.java
@@ -26,7 +26,9 @@ import com.rometools.certiorem.web.AbstractSubServlet;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 @Singleton
 public class SubServlet extends AbstractSubServlet {
 

--- a/rome-certiorem-webapp/src/main/java/com/rometools/certiorem/webapp/SubTest.java
+++ b/rome-certiorem-webapp/src/main/java/com/rometools/certiorem/webapp/SubTest.java
@@ -35,7 +35,9 @@ import com.rometools.fetcher.impl.SyndFeedInfo;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 @Singleton
 public class SubTest extends HttpServlet {
 

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/HttpStatusCodeException.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/HttpStatusCodeException.java
@@ -21,7 +21,9 @@ package com.rometools.certiorem;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class HttpStatusCodeException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/DeltaFeedInfoCache.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/DeltaFeedInfoCache.java
@@ -28,7 +28,9 @@ import com.rometools.fetcher.impl.SyndFeedInfo;
  * changes to entries in the underlying feed.
  *
  * @author najmi
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class DeltaFeedInfoCache implements FeedFetcherCache {
 
     FeedFetcherCache backingCache;

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/DeltaSyndFeedInfo.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/DeltaSyndFeedInfo.java
@@ -35,7 +35,9 @@ import com.rometools.rome.feed.synd.SyndFeed;
  * fetch.
  *
  * @author najmi
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class DeltaSyndFeedInfo extends SyndFeedInfo {
 
     /**

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/Hub.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/Hub.java
@@ -43,7 +43,9 @@ import com.rometools.rome.feed.synd.SyndFeed;
  * a very thin servlet wrapper, or other, non-HTTP notification methods you might want to use.
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class Hub {
 
     private static final Logger LOG = LoggerFactory.getLogger(Hub.class);

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/Notifier.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/Notifier.java
@@ -27,7 +27,9 @@ import com.rometools.rome.feed.synd.SyndFeed;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public interface Notifier {
     /**
      * Instructs the notifier to begin sending notifications to the list of subscribers

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/Verifier.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/Verifier.java
@@ -24,7 +24,9 @@ import com.rometools.certiorem.hub.data.Subscriber;
  * A strategy interface for verification of subscriptions.
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public interface Verifier {
 
     /**

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/data/HubDAO.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/data/HubDAO.java
@@ -23,7 +23,9 @@ import java.util.List;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public interface HubDAO {
 
     public List<? extends Subscriber> subscribersForTopic(String topic);

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/data/Subscriber.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/data/Subscriber.java
@@ -23,7 +23,9 @@ import java.io.Serializable;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class Subscriber implements Serializable {
     /**
      *

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/data/SubscriptionSummary.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/data/SubscriptionSummary.java
@@ -23,7 +23,9 @@ import java.io.Serializable;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class SubscriptionSummary implements Serializable {
     /**
      *

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/data/jpa/JPADAO.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/data/jpa/JPADAO.java
@@ -35,7 +35,9 @@ import com.rometools.certiorem.hub.data.SubscriptionSummary;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class JPADAO implements HubDAO {
 
     private final EntityManagerFactory factory;

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/data/jpa/JPASubscriber.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/data/jpa/JPASubscriber.java
@@ -33,7 +33,9 @@ import com.rometools.certiorem.hub.data.Subscriber;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 @Entity
 @NamedQueries({ @NamedQuery(name = "Subcriber.forTopic", query = "SELECT o FROM JPASubscriber o WHERE o.topic = :topic AND o.expired = false ORDER BY o.subscribedAt") })
 public class JPASubscriber extends Subscriber implements Serializable {

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/data/ram/InMemoryHubDAO.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/data/ram/InMemoryHubDAO.java
@@ -32,7 +32,9 @@ import com.rometools.certiorem.hub.data.SubscriptionSummary;
  * A Simple In-Memory HubDAO for subscribers.
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class InMemoryHubDAO implements HubDAO {
     private final ConcurrentHashMap<String, List<Subscriber>> subscribers = new ConcurrentHashMap<String, List<Subscriber>>();
     private final ConcurrentHashMap<String, ConcurrentHashMap<String, SubscriptionSummary>> summaries = new ConcurrentHashMap<String, ConcurrentHashMap<String, SubscriptionSummary>>();

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/notify/standard/AbstractNotifier.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/notify/standard/AbstractNotifier.java
@@ -40,7 +40,9 @@ import com.rometools.rome.io.SyndFeedOutput;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public abstract class AbstractNotifier implements Notifier {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractNotifier.class);

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/notify/standard/Notification.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/notify/standard/Notification.java
@@ -24,7 +24,9 @@ import com.rometools.certiorem.hub.data.Subscriber;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class Notification {
 
     int retryCount = 0;

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/notify/standard/ThreadPoolNotifier.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/notify/standard/ThreadPoolNotifier.java
@@ -31,7 +31,9 @@ import com.rometools.certiorem.hub.data.SubscriptionSummary;
  * A notifier implementation that uses a thread pool to deliver notifications to subscribers
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class ThreadPoolNotifier extends AbstractNotifier {
     private static final long TWO_MINUTES = 2 * 60 * 1000;
     protected final ThreadPoolExecutor exeuctor;

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/notify/standard/UnthreadedNotifier.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/notify/standard/UnthreadedNotifier.java
@@ -24,7 +24,9 @@ import com.rometools.certiorem.hub.data.SubscriptionSummary;
  * A notifier that does not use threads. All calls are blocking and synchronous.
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class UnthreadedNotifier extends AbstractNotifier {
 
     /**

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/verify/standard/AbstractVerifier.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/verify/standard/AbstractVerifier.java
@@ -39,7 +39,9 @@ import com.rometools.certiorem.hub.data.Subscriber;
  * operations, and expects a child class to do Async ops.
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public abstract class AbstractVerifier implements Verifier {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractVerifier.class);

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/verify/standard/ThreadPoolVerifier.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/verify/standard/ThreadPoolVerifier.java
@@ -28,7 +28,9 @@ import com.rometools.certiorem.hub.data.Subscriber;
  * Uses a ThreadPoolExecutor to do async verifications.
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class ThreadPoolVerifier extends AbstractVerifier {
     protected final ThreadPoolExecutor exeuctor;
 

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/verify/standard/ThreadpoolVerifierAdvanced.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/verify/standard/ThreadpoolVerifierAdvanced.java
@@ -23,7 +23,9 @@ import java.util.concurrent.ThreadPoolExecutor;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class ThreadpoolVerifierAdvanced extends ThreadPoolVerifier {
 
     public ThreadpoolVerifierAdvanced(final ThreadPoolExecutor executor) {

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/hub/verify/standard/UnthreadedVerifier.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/hub/verify/standard/UnthreadedVerifier.java
@@ -24,7 +24,9 @@ import com.rometools.certiorem.hub.data.Subscriber;
  * A verifier that does not use threads. Suitable for Google App Engine.
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class UnthreadedVerifier extends AbstractVerifier {
 
     @Override

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/pub/NotificationException.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/pub/NotificationException.java
@@ -21,7 +21,9 @@ package com.rometools.certiorem.pub;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class NotificationException extends Exception {
 
     /**

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/pub/Publisher.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/pub/Publisher.java
@@ -36,7 +36,9 @@ import com.rometools.rome.feed.synd.SyndLink;
  * A class for sending update notifications to a hub.
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class Publisher {
 
     private static final Logger LOG = LoggerFactory.getLogger(Publisher.class);

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/sub/Requester.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/sub/Requester.java
@@ -23,7 +23,9 @@ import com.rometools.certiorem.sub.data.Subscription;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public interface Requester {
     public void sendSubscribeRequest(String hubUrl, Subscription subscription, String verifySync, long leaseSeconds, String secret, String callbackUrl,
             RequestCallback callback);

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/sub/Subscriptions.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/sub/Subscriptions.java
@@ -47,7 +47,9 @@ import com.rometools.rome.io.SyndFeedInput;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class Subscriptions {
 
     private static final Logger LOG = LoggerFactory.getLogger(Subscriptions.class);

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/sub/data/SubDAO.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/sub/data/SubDAO.java
@@ -21,7 +21,9 @@ package com.rometools.certiorem.sub.data;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public interface SubDAO {
 
     public Subscription findById(String id);

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/sub/data/Subscription.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/sub/data/Subscription.java
@@ -23,7 +23,9 @@ import java.io.Serializable;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class Subscription implements Serializable {
     /**
      *

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/sub/data/SubscriptionCallback.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/sub/data/SubscriptionCallback.java
@@ -23,7 +23,9 @@ import com.rometools.fetcher.impl.SyndFeedInfo;
 /**
  *
  * @author najmi
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public interface SubscriptionCallback {
 
     void onNotify(Subscription subscribed, SyndFeedInfo feedInfo);

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/sub/data/ram/InMemorySubDAO.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/sub/data/ram/InMemorySubDAO.java
@@ -35,7 +35,9 @@ import com.rometools.certiorem.sub.data.Subscription;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class InMemorySubDAO implements SubDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(InMemorySubDAO.class);

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/sub/request/AbstractRequester.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/sub/request/AbstractRequester.java
@@ -29,7 +29,9 @@ import com.rometools.certiorem.sub.data.Subscription;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public abstract class AbstractRequester implements Requester {
 
     protected boolean sendRequest(final String hubUrl, final String mode, final Subscription subscription, final String verifySync, final long leaseSeconds,

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/sub/request/AsyncRequester.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/sub/request/AsyncRequester.java
@@ -29,7 +29,9 @@ import com.rometools.certiorem.sub.data.Subscription;
  * A simple requester implementation that always makes requests as Async.
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class AsyncRequester extends AbstractRequester {
 
     private static final Logger LOG = LoggerFactory.getLogger(AsyncRequester.class);

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/sub/request/SyncRequester.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/sub/request/SyncRequester.java
@@ -33,7 +33,9 @@ import com.rometools.certiorem.sub.data.Subscription;
  * A simple requester implementation that always makes requests as Async.
  *
  * @author Farrukh Najmi
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public class SyncRequester extends AbstractRequester {
 
     private static final Logger LOG = LoggerFactory.getLogger(SyncRequester.class);

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/web/AbstractHubServlet.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/web/AbstractHubServlet.java
@@ -32,7 +32,9 @@ import com.rometools.certiorem.hub.Hub;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public abstract class AbstractHubServlet extends HttpServlet {
     /**
      *

--- a/rome-certiorem/src/main/java/com/rometools/certiorem/web/AbstractSubServlet.java
+++ b/rome-certiorem/src/main/java/com/rometools/certiorem/web/AbstractSubServlet.java
@@ -32,7 +32,9 @@ import com.rometools.certiorem.sub.Subscriptions;
 /**
  *
  * @author robert.cooper
+ * @deprecated Certiorem will be removed in Rome 2.
  */
+@Deprecated
 public abstract class AbstractSubServlet extends HttpServlet {
 
     private static final long serialVersionUID = 1L;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/client/AtomClientFactory.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/client/AtomClientFactory.java
@@ -21,7 +21,10 @@ import com.rometools.rome.io.impl.Atom10Parser;
 /**
  * Creates AtomService or ClientCollection based on username, password and end-point URI of Atom
  * protocol service.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AtomClientFactory {
 
     static {

--- a/rome-propono/src/main/java/com/rometools/propono/atom/client/AuthStrategy.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/client/AuthStrategy.java
@@ -15,11 +15,15 @@
  */
 package com.rometools.propono.atom.client;
 
+import com.rometools.propono.utils.ProponoException;
+
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethodBase;
 
-import com.rometools.propono.utils.ProponoException;
-
+/**
+ * @deprecated Propono will be removed in Rome 2.
+ */
+@Deprecated
 public interface AuthStrategy {
 
     /**

--- a/rome-propono/src/main/java/com/rometools/propono/atom/client/BasicAuthStrategy.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/client/BasicAuthStrategy.java
@@ -21,6 +21,10 @@ import org.apache.commons.httpclient.HttpMethodBase;
 import com.rometools.propono.utils.ProponoException;
 import com.rometools.rome.io.impl.Base64;
 
+/**
+ * @deprecated Propono will be removed in Rome 2.
+ */
+@Deprecated
 public class BasicAuthStrategy implements AuthStrategy {
     private final String credentials;
 

--- a/rome-propono/src/main/java/com/rometools/propono/atom/client/ClientAtomService.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/client/ClientAtomService.java
@@ -39,7 +39,10 @@ import com.rometools.rome.io.impl.Atom10Parser;
  * {@link com.rometools.rome.propono.atom.common.Collection} class to add a <code>getEntry()</code>
  * method and to return {@link com.rometools.rome.propono.atom.client.ClientWorkspace} objects
  * instead of common {@link com.rometools.rome.propono.atom.common.Workspace}s.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class ClientAtomService extends AtomService {
 
     private static final Logger LOG = LoggerFactory.getLogger(ClientAtomService.class);

--- a/rome-propono/src/main/java/com/rometools/propono/atom/client/ClientCategories.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/client/ClientCategories.java
@@ -32,7 +32,10 @@ import com.rometools.propono.utils.ProponoException;
 /**
  * Models an Atom protocol Categories element, which may contain ROME Atom
  * {@link com.rometools.rome.feed.atom.Category} elements.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class ClientCategories extends Categories {
     private ClientCollection clientCollection = null;
 

--- a/rome-propono/src/main/java/com/rometools/propono/atom/client/ClientCollection.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/client/ClientCollection.java
@@ -38,7 +38,10 @@ import com.rometools.rome.io.impl.Atom10Parser;
 /**
  * Models an Atom collection, extends Collection and adds methods for adding, retrieving, updateing
  * and deleting entries.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class ClientCollection extends Collection {
 
     private final boolean writable = true;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/client/ClientEntry.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/client/ClientEntry.java
@@ -47,7 +47,10 @@ import com.rometools.rome.io.impl.Atom10Parser;
 /**
  * Client implementation of Atom entry, extends ROME Entry to add methods for easily getting/setting
  * content, updating and removing the entry from the server.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class ClientEntry extends Entry {
 
     private static final long serialVersionUID = 1L;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/client/ClientMediaEntry.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/client/ClientMediaEntry.java
@@ -49,7 +49,10 @@ import com.rometools.rome.io.impl.Atom10Parser;
 /**
  * Client implementation of Atom media-link entry, an Atom entry that provides meta-data for a media
  * file (e.g. uploaded image or audio file).
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class ClientMediaEntry extends ClientEntry {
 
     private static final long serialVersionUID = 1L;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/client/ClientWorkspace.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/client/ClientWorkspace.java
@@ -28,7 +28,10 @@ import com.rometools.propono.utils.ProponoException;
  * {@link com.rometools.rome.propono.atom.common.Workspace} to return
  * {@link com.rometools.rome.propono.atom.client.ClientCollection} objects instead of common
  * {@link com.rometools.rome.propono.atom.common.Collection}s.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class ClientWorkspace extends Workspace {
 
     private ClientAtomService atomService = null;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/client/EntryIterator.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/client/EntryIterator.java
@@ -33,7 +33,10 @@ import com.rometools.rome.io.WireFeedInput;
 
 /**
  * Enables iteration over entries in Atom protocol collection.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class EntryIterator implements Iterator<ClientEntry> {
 
     private static final Logger LOG = LoggerFactory.getLogger(EntryIterator.class);

--- a/rome-propono/src/main/java/com/rometools/propono/atom/client/GDataAuthStrategy.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/client/GDataAuthStrategy.java
@@ -22,6 +22,10 @@ import org.apache.commons.httpclient.methods.PostMethod;
 
 import com.rometools.propono.utils.ProponoException;
 
+/**
+ * @deprecated Propono will be removed in Rome 2.
+ */
+@Deprecated
 public class GDataAuthStrategy implements AuthStrategy {
     private final String email;
     private final String password;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/client/NoAuthStrategy.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/client/NoAuthStrategy.java
@@ -22,7 +22,10 @@ import com.rometools.propono.utils.ProponoException;
 
 /**
  * No authentication
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class NoAuthStrategy implements AuthStrategy {
 
     @Override

--- a/rome-propono/src/main/java/com/rometools/propono/atom/client/OAuthStrategy.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/client/OAuthStrategy.java
@@ -39,7 +39,10 @@ import com.rometools.propono.utils.ProponoException;
 
 /**
  * Strategy for using OAuth.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class OAuthStrategy implements AuthStrategy {
 
     private State state = State.UNAUTHORIZED;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/common/AtomService.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/common/AtomService.java
@@ -29,7 +29,10 @@ import com.rometools.propono.utils.ProponoException;
 /**
  * Models an Atom Publishing Protocol Service Document. Is able to read a Service document from a
  * JDOM Document and to write Service document out as a JDOM Document.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AtomService {
 
     private List<Workspace> workspaces = new ArrayList<Workspace>();

--- a/rome-propono/src/main/java/com/rometools/propono/atom/common/Categories.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/common/Categories.java
@@ -28,7 +28,10 @@ import com.rometools.rome.io.impl.Atom10Parser;
 /**
  * Models an Atom protocol Categories element, which may contain ROME Atom
  * {@link com.rometools.rome.feed.atom.Category} elements.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class Categories {
 
     private final List<Category> categories = new ArrayList<Category>();

--- a/rome-propono/src/main/java/com/rometools/propono/atom/common/Collection.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/common/Collection.java
@@ -27,7 +27,10 @@ import com.rometools.rome.io.impl.Atom10Parser;
 
 /**
  * Models an Atom workspace collection.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class Collection {
 
     public static final String ENTRY_TYPE = "application/atom+xml;type=entry";

--- a/rome-propono/src/main/java/com/rometools/propono/atom/common/Workspace.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/common/Workspace.java
@@ -26,7 +26,10 @@ import com.rometools.propono.utils.ProponoException;
 
 /**
  * Models an Atom workspace.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class Workspace {
 
     private String title = null;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/common/rome/AppModule.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/common/rome/AppModule.java
@@ -25,7 +25,10 @@ import com.rometools.rome.feed.module.Module;
 
 /**
  * ROME Extension Module to Atom protocol extensions to Atom format.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public interface AppModule extends Module {
 
     public static final String URI = "http://www.w3.org/2007/app";

--- a/rome-propono/src/main/java/com/rometools/propono/atom/common/rome/AppModuleGenerator.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/common/rome/AppModuleGenerator.java
@@ -34,7 +34,10 @@ import com.rometools.rome.io.ModuleGenerator;
 
 /**
  * Creates JDOM representation for APP Extension Module.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AppModuleGenerator implements ModuleGenerator {
 
     private static final Namespace APP_NS = Namespace.getNamespace("app", AppModule.URI);

--- a/rome-propono/src/main/java/com/rometools/propono/atom/common/rome/AppModuleImpl.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/common/rome/AppModuleImpl.java
@@ -27,7 +27,10 @@ import com.rometools.rome.feed.module.ModuleImpl;
 
 /**
  * Bean representation of APP module.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AppModuleImpl extends ModuleImpl implements AppModule {
 
     private static final long serialVersionUID = 1L;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/common/rome/AppModuleParser.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/common/rome/AppModuleParser.java
@@ -30,7 +30,10 @@ import com.rometools.rome.io.impl.DateParser;
 
 /**
  * Parses APP module information from a JDOM element and into <code>AppModule</code> form.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AppModuleParser implements ModuleParser {
 
     /** Get URI of module namespace */

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomException.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomException.java
@@ -24,7 +24,10 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Exception thrown by {@link com.rometools.rome.propono.atom.server.AtomHandler} and extended by
  * other Propono Atom exception classes.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AtomException extends Exception {
 
     private static final long serialVersionUID = 1L;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomHandler.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomHandler.java
@@ -32,7 +32,10 @@ import com.rometools.rome.feed.atom.Feed;
  * concrete sub-class of {@link com.rometools.rome.propono.atom.server.AtomHandlerFactory} which is
  * capable of instantiating it.
  * </p>
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public interface AtomHandler {
     /**
      * Get username of authenticated user. Return the username of the authenticated user

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomHandlerFactory.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomHandlerFactory.java
@@ -31,7 +31,10 @@ import org.slf4j.LoggerFactory;
  * factory that is capable of creating instances of your
  * {@link com.rometools.rome.propono.atom.server.AtomHandler} impementation.
  * </p>
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public abstract class AtomHandlerFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(AtomHandlerFactory.class);

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomMediaResource.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomMediaResource.java
@@ -27,7 +27,10 @@ import javax.activation.MimetypesFileTypeMap;
 
 /**
  * Represents a media link entry.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AtomMediaResource {
     private String contentType = null;
     private long contentLength = 0;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomNotAuthorizedException.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomNotAuthorizedException.java
@@ -24,7 +24,10 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Exception to be thrown by <code>AtomHandler</code> implementations in the case that a user is not
  * authorized to access a resource.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AtomNotAuthorizedException extends AtomException {
 
     private static final long serialVersionUID = 1L;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomNotFoundException.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomNotFoundException.java
@@ -23,7 +23,10 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Exception thrown by AtomHandler in that case a resource is not found.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AtomNotFoundException extends AtomException {
 
     private static final long serialVersionUID = 1L;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomRequest.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomRequest.java
@@ -27,7 +27,10 @@ import java.util.Map;
 
 /**
  * Represents HTTP request to be processed by AtomHandler.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public interface AtomRequest {
 
     /**

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomRequestImpl.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomRequestImpl.java
@@ -29,7 +29,10 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * Default request implementation.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AtomRequestImpl implements AtomRequest {
 
     private HttpServletRequest wrapped = null;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomServlet.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/AtomServlet.java
@@ -55,7 +55,10 @@ import com.rometools.rome.io.impl.Atom10Parser;
  * care of parsing incoming XML into ROME Atom {@link com.rometools.rome.feed.atom.Entry} objects,
  * passing those to the handler and serializing to the response the entries and feeds returned by
  * the handler.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AtomServlet extends HttpServlet {
 
     private static final long serialVersionUID = 1L;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/ConfigurationError.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/ConfigurationError.java
@@ -15,6 +15,10 @@
  */
 package com.rometools.propono.atom.server;
 
+/**
+ * @deprecated Propono will be removed in Rome 2.
+ */
+@Deprecated
 class ConfigurationError extends Error {
 
     private static final long serialVersionUID = 1L;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/FactoryConfigurationError.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/FactoryConfigurationError.java
@@ -20,7 +20,10 @@ package com.rometools.propono.atom.server;
  * {@link com.rometools.rome.propono.atom.server.AtomHandlerFactory} exists. This error will
  * typically be thrown when the class of a parser factory specified in the system properties cannot
  * be found or instantiated.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class FactoryConfigurationError extends Error {
 
     private static final long serialVersionUID = 1L;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/FactoryFinder.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/FactoryFinder.java
@@ -24,7 +24,10 @@ import java.util.Properties;
 /**
  * Find {@link com.rometools.rome.propono.atom.server.AtomHandlerFactory} based on properties
  * files.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 class FactoryFinder {
 
     private static boolean debug = false;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/SecuritySupport.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/SecuritySupport.java
@@ -27,7 +27,10 @@ import java.security.PrivilegedExceptionAction;
 /**
  * This class is duplicated for each subpackage, it is package private and therefore is not exposed
  * as part of the public API.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 class SecuritySupport {
 
     ClassLoader getContextClassLoader() {

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/impl/FileBasedAtomHandler.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/impl/FileBasedAtomHandler.java
@@ -39,7 +39,10 @@ import com.rometools.rome.feed.atom.Feed;
  * File-based {@link com.rometools.rome.propono.atom.server.AtomHandler} implementation that stores
  * entries and media-entries to disk. Implemented using
  * {@link com.rometools.rome.propono.atom.server.impl.FileBasedAtomService}.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class FileBasedAtomHandler implements AtomHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileBasedAtomHandler.class);

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/impl/FileBasedAtomHandlerFactory.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/impl/FileBasedAtomHandlerFactory.java
@@ -24,7 +24,10 @@ import com.rometools.propono.atom.server.AtomHandlerFactory;
 /**
  * Extends {@link com.rometools.rome.propono.atom.server.AtomHandlerFactory} to create and return
  * {@link com.rometools.rome.propono.atom.server.impl.FileBasedAtomHandler}.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class FileBasedAtomHandlerFactory extends AtomHandlerFactory {
 
     /**

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/impl/FileBasedAtomService.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/impl/FileBasedAtomService.java
@@ -93,7 +93,10 @@ import com.rometools.propono.utils.Utilities;
  * Collection entry media (media file stored under entry directory)<br/>
  * <code>[servlet-context-dir]/[workspace-handle]/[collection-plural]/id/media/id</code>
  * </p>
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class FileBasedAtomService extends AtomService {
 
     private final Map<String, FileBasedWorkspace> workspaceMap = new TreeMap<String, FileBasedWorkspace>();

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/impl/FileBasedCollection.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/impl/FileBasedCollection.java
@@ -63,7 +63,10 @@ import com.rometools.rome.io.impl.Atom10Parser;
  * File based Atom collection implementation. This is the heart of the file-based Atom service
  * implementation. It provides methods for adding, getting updating and deleting Atom entries and
  * media entries.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class FileBasedCollection extends Collection {
 
     private String handle = null;

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/impl/FileBasedWorkspace.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/impl/FileBasedWorkspace.java
@@ -19,7 +19,10 @@ import com.rometools.propono.atom.common.Workspace;
 
 /**
  * File based Atom service Workspace.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class FileBasedWorkspace extends Workspace {
 
     public FileBasedWorkspace(final String handle, final String baseDir) {

--- a/rome-propono/src/main/java/com/rometools/propono/atom/server/impl/FileStore.java
+++ b/rome-propono/src/main/java/com/rometools/propono/atom/server/impl/FileStore.java
@@ -31,7 +31,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Class which helps in handling File persistence related operations.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 class FileStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileStore.class);

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/BaseBlogEntry.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/BaseBlogEntry.java
@@ -21,7 +21,10 @@ import java.util.List;
 
 /**
  * Base implementation of a blog entry.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public abstract class BaseBlogEntry implements BlogEntry {
     protected String id = null;
     protected Person author = null;

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/Blog.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/Blog.java
@@ -24,7 +24,10 @@ import java.util.List;
  * using the getCollections() and getCollection(String name) methods, which return Blog.Collection
  * objects, which you can use to create, retrieve update or delete entries within a collection.
  * </p>
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public interface Blog {
 
     /**

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/BlogClientException.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/BlogClientException.java
@@ -18,7 +18,10 @@ package com.rometools.propono.blogclient;
 /**
  * Represents a Blog Client exception, the library throws these instead of implementation specific
  * exceptions.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class BlogClientException extends Exception {
 
     private static final long serialVersionUID = 1L;

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/BlogConnection.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/BlogConnection.java
@@ -20,7 +20,10 @@ import java.util.List;
 /**
  * A BlogConnection is a single-user connection to a blog server where the user has access to
  * multiple blogs, which are each represented by a Blog interface.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public interface BlogConnection {
 
     /** Returns collection of blogs available from this connection */

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/BlogConnectionFactory.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/BlogConnectionFactory.java
@@ -19,7 +19,10 @@ import java.lang.reflect.Constructor;
 
 /**
  * Entry point to the Blogapps blog client library.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class BlogConnectionFactory {
 
     // BlogConnection implementations must:

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/BlogEntry.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/BlogEntry.java
@@ -20,7 +20,10 @@ import java.util.List;
 
 /**
  * Represents a single blog entry.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public interface BlogEntry {
 
     /** Get token, which can be used to fetch the blog entry */

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/BlogResource.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/BlogResource.java
@@ -23,7 +23,10 @@ import java.io.InputStream;
  * Resources are modeled as a type of BlogEntry, but be aware: not all servers can save resource
  * metadata (i.e. title, category, author, etc.). MetaWeblog based servers can't save metadata at
  * all and Atom protocol servers are not required to preserve uploaded file metadata.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public interface BlogResource extends BlogEntry {
 
     /** Get resource name (name is required) */

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/atomprotocol/AtomBlog.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/atomprotocol/AtomBlog.java
@@ -34,7 +34,10 @@ import com.rometools.propono.utils.ProponoException;
 
 /**
  * Atom protocol implementation of the BlogClient Blog interface.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AtomBlog implements Blog {
 
     private String name = null;

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/atomprotocol/AtomCollection.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/atomprotocol/AtomCollection.java
@@ -31,7 +31,10 @@ import com.rometools.rome.feed.atom.Category;
 
 /**
  * Atom protocol implementation of BlogClient Blog.Collection.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AtomCollection implements Blog.Collection {
 
     private Blog blog = null;

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/atomprotocol/AtomConnection.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/atomprotocol/AtomConnection.java
@@ -33,7 +33,10 @@ import com.rometools.propono.blogclient.BlogConnection;
 /**
  * Atom protocol of BlogConnection. Connects to Atom server, creates AtomBlog object for each Atom
  * workspace found and within each blog a collection for each Atom collection found.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AtomConnection implements BlogConnection {
 
     private final Map<String, Blog> blogs = new HashMap<String, Blog>();

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/atomprotocol/AtomEntry.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/atomprotocol/AtomEntry.java
@@ -33,7 +33,10 @@ import com.rometools.rome.feed.synd.SyndPerson;
 
 /**
  * Atom protocol implementation of BlogEntry.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AtomEntry extends BaseBlogEntry implements BlogEntry {
 
     String editURI = null;

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/atomprotocol/AtomEntryIterator.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/atomprotocol/AtomEntryIterator.java
@@ -27,7 +27,10 @@ import com.rometools.propono.blogclient.BlogEntry;
 
 /**
  * Atom protocol implementation of BlogClient entry iterator.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AtomEntryIterator implements Iterator<BlogEntry> {
 
     private static final Logger LOG = LoggerFactory.getLogger(AtomEntryIterator.class);

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/atomprotocol/AtomResource.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/atomprotocol/AtomResource.java
@@ -29,7 +29,10 @@ import com.rometools.rome.feed.atom.Link;
 
 /**
  * Atom protocol implementation of BlogResource.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class AtomResource extends AtomEntry implements BlogResource {
 
     private AtomCollection collection;

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/metaweblog/MetaWeblogBlog.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/metaweblog/MetaWeblogBlog.java
@@ -37,7 +37,10 @@ import com.rometools.propono.blogclient.BlogResource;
 
 /**
  * Blog implementation that uses a mix of Blogger and MetaWeblog API methods.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class MetaWeblogBlog implements Blog {
 
     private final String blogid;

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/metaweblog/MetaWeblogConnection.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/metaweblog/MetaWeblogConnection.java
@@ -32,7 +32,10 @@ import com.rometools.propono.blogclient.BlogConnection;
 
 /**
  * BlogClient implementation that uses a mix of Blogger and MetaWeblog API methods.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class MetaWeblogConnection implements BlogConnection {
 
     private URL url = null;

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/metaweblog/MetaWeblogEntry.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/metaweblog/MetaWeblogEntry.java
@@ -27,7 +27,10 @@ import com.rometools.propono.blogclient.BlogEntry;
 
 /**
  * MetaWeblog API implementation of an entry.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class MetaWeblogEntry extends BaseBlogEntry {
 
     MetaWeblogEntry(final MetaWeblogBlog blog, final Map<String, Object> entryMap) {

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/metaweblog/MetaWeblogResource.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/metaweblog/MetaWeblogResource.java
@@ -26,7 +26,10 @@ import com.rometools.propono.blogclient.BlogResource;
 
 /**
  * MetaWeblog API implementation of an resource entry.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class MetaWeblogResource extends MetaWeblogEntry implements BlogResource {
     private final MetaWeblogBlog blog;
     private final String name;

--- a/rome-propono/src/main/java/com/rometools/propono/blogclient/metaweblog/NoOpIterator.java
+++ b/rome-propono/src/main/java/com/rometools/propono/blogclient/metaweblog/NoOpIterator.java
@@ -17,6 +17,10 @@ package com.rometools.propono.blogclient.metaweblog;
 
 import java.util.Iterator;
 
+/**
+ * @deprecated Propono will be removed in Rome 2.
+ */
+@Deprecated
 class NoOpIterator<T> implements Iterator<T> {
 
     /** No-op */

--- a/rome-propono/src/main/java/com/rometools/propono/utils/ProponoException.java
+++ b/rome-propono/src/main/java/com/rometools/propono/utils/ProponoException.java
@@ -20,7 +20,10 @@ import java.io.PrintWriter;
 
 /**
  * Base Propono exception class.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public class ProponoException extends Exception {
 
     private static final long serialVersionUID = 1L;

--- a/rome-propono/src/main/java/com/rometools/propono/utils/Utilities.java
+++ b/rome-propono/src/main/java/com/rometools/propono/utils/Utilities.java
@@ -30,7 +30,10 @@ import java.util.regex.Pattern;
 
 /**
  * Utilities for file I/O and string manipulation.
+ *
+ * @deprecated Propono will be removed in Rome 2.
  */
+@Deprecated
 public final class Utilities {
 
     private static final String LS = System.getProperty("line.separator");


### PR DESCRIPTION
Certiorem and Propono depend on rome-fetcher which is now deprecated and
will be removed in the next major version (see #276).