### PR TITLE
Fixing extra whitespace in GeoRSS

### DIFF
--- a/rome-modules/src/main/java/com/rometools/modules/georss/GMLParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/GMLParser.java
@@ -51,7 +51,7 @@ public class GMLParser implements ModuleParser {
 
     private static PositionList parsePosList(final Element element) {
         final String coordinates = element.getText();
-        final String[] coord = Strings.trimToEmpty(coordinates).split(" ");
+        final String[] coord = Strings.trimToEmpty(coordinates).split("\\s+");
         final PositionList posList = new PositionList();
         for (int i = 0; i < coord.length; i += 2) {
             posList.add(Double.parseDouble(coord[i]), Double.parseDouble(coord[i + 1]));
@@ -71,7 +71,7 @@ public class GMLParser implements ModuleParser {
             if (posElement != null) {
                 geoRSSModule = new GMLModuleImpl();
                 final String coordinates = posElement.getText();
-                final String[] coord = Strings.trimToEmpty(coordinates).split(" ");
+                final String[] coord = Strings.trimToEmpty(coordinates).split("\\s+");
                 final Position pos = new Position(Double.parseDouble(coord[0]), Double.parseDouble(coord[1]));
                 geoRSSModule.setGeometry(new Point(pos));
             }
@@ -129,9 +129,9 @@ public class GMLParser implements ModuleParser {
             if (lowerElement != null && upperElement != null) {
                 geoRSSModule = new GMLModuleImpl();
                 final String lowerCoordinates = lowerElement.getText();
-                final String[] lowerCoord = Strings.trimToEmpty(lowerCoordinates).split(" ");
+                final String[] lowerCoord = Strings.trimToEmpty(lowerCoordinates).split("\\s+");
                 final String upperCoordinates = upperElement.getText();
-                final String[] upperCoord = Strings.trimToEmpty(upperCoordinates).split(" ");
+                final String[] upperCoord = Strings.trimToEmpty(upperCoordinates).split("\\s+");
                 final Envelope envelope = new Envelope(Double.parseDouble(lowerCoord[0]), Double.parseDouble(lowerCoord[1]), Double.parseDouble(upperCoord[0]),
                         Double.parseDouble(upperCoord[1]));
                 geoRSSModule.setGeometry(envelope);

--- a/rome-modules/src/main/java/com/rometools/modules/georss/SimpleParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/georss/SimpleParser.java
@@ -50,7 +50,7 @@ public class SimpleParser implements ModuleParser {
         if (coordinates != null) {
 
             posList = new PositionList();
-            final String[] coord = coordinates.split(" ");
+            final String[] coord = coordinates.split("\\s+");
             for (int i = 0; i < coord.length; i += 2) {
                 final double latitude = Double.parseDouble(coord[i]);
                 final double longitude = Double.parseDouble(coord[i + 1]);
@@ -83,7 +83,7 @@ public class SimpleParser implements ModuleParser {
             final String coordinates = Strings.trimToNull(pointElement.getText());
             if (coordinates != null) {
 
-                final String[] coord = coordinates.split(" ");
+                final String[] coord = coordinates.split("\\s+");
 
                 if (coord.length == 2) {
 
@@ -138,7 +138,7 @@ public class SimpleParser implements ModuleParser {
             final String coordinates = Strings.trimToNull(boxElement.getText());
             if (coordinates != null) {
 
-                final String[] coord = coordinates.split(" ");
+                final String[] coord = coordinates.split("\\s+");
                 final double bottom = Double.parseDouble(coord[0]);
                 final double left = Double.parseDouble(coord[1]);
                 final double top = Double.parseDouble(coord[2]);

--- a/rome-modules/src/test/java/com/rometools/modules/georss/GeoRSSModuleTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/georss/GeoRSSModuleTest.java
@@ -280,10 +280,10 @@ public class GeoRSSModuleTest extends AbstractTestCase {
     }
     
     public void testDoubleSpacePointValue() throws Exception {
-    	final Double[] lat = { 31.7666667, 31.7666667, 31.7666667 };
+        final Double[] lat = { 31.7666667, 31.7666667, 31.7666667 };
         final Double[] lng = { 35.2333333, 35.2333333, 35.2333333 };
-    	
-    	assertTestFile("georss-double-space-issue.xml", lat, lng);
+        
+        assertTestFile("georss-double-space-issue.xml", lat, lng);
     }
 
     private SyndFeed getSyndFeed(final String filePath) throws IOException, FeedException {

--- a/rome-modules/src/test/java/com/rometools/modules/georss/GeoRSSModuleTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/georss/GeoRSSModuleTest.java
@@ -278,6 +278,13 @@ public class GeoRSSModuleTest extends AbstractTestCase {
         // only tests whether file can be parsed (there should be no exception)
         getSyndFeed("org/rometools/feed/module/georss/issue-02.xml");
     }
+    
+    public void testDoubleSpacePointValue() throws Exception {
+    	final Double[] lat = { 31.7666667, 31.7666667, 31.7666667 };
+        final Double[] lng = { 35.2333333, 35.2333333, 35.2333333 };
+    	
+    	assertTestFile("georss-double-space-issue.xml", lat, lng);
+    }
 
     private SyndFeed getSyndFeed(final String filePath) throws IOException, FeedException {
         final String fullPath = getTestFile(filePath);

--- a/rome-modules/src/test/resources/data/georss-double-space-issue.xml
+++ b/rome-modules/src/test/resources/data/georss-double-space-issue.xml
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:georss="http://www.georss.org/georss">
+<channel>
+<title>GeoNames.org recent changes</title>
+<link>http://www.geonames.org/recent-changes.html</link>
+<description>50 most recent modifications</description>
+<item>
+<title>Jerusalem</title>
+<link>http://www.geonames.org/maps/geonameId=281184</link>
+<guid>http://www.geonames.org/maps/geonameId=281184&amp;revision=80</guid>
+<description>delete name :la,Hierusalem </description>
+<pubDate>Mon, 03 Apr 2006 10:35:16 +0200</pubDate>
+<georss:point>31.7666667  35.2333333</georss:point>
+</item>
+<item>
+<title>Jerusalem</title>
+<link>http://www.geonames.org/maps/geonameId=281184</link>
+<guid>http://www.geonames.org/maps/geonameId=281184&amp;revision=72</guid>
+<description>add name :he,Ir Ha-Qodesh</description>
+<pubDate>Mon, 03 Apr 2006 10:32:24 +0200</pubDate>
+<georss:point>31.7666667  35.2333333</georss:point>
+</item>
+<item>
+<title>Jerusalem</title>
+<link>http://www.geonames.org/maps/geonameId=281184</link>
+<guid>http://www.geonames.org/maps/geonameId=281184&amp;revision=31</guid>
+<description>update name :grc,Μωριας</description>
+<pubDate>Mon, 03 Apr 2006 10:17:41 +0200</pubDate>
+<georss:point>31.7666667  35.2333333</georss:point>
+</item>
+</channel>
+</rss>


### PR DESCRIPTION
I fixed issue where more than one space in "<georss:point>" elements
caused parsing to fail.

Although most implementations of GeoRSS use one space between the
coordinates, the specification technically allows for more than one
whitespace character. See http://www.georss.org/simple.html for details.