### PR TITLE
Improved Atom Module to work with several links (2)

### DIFF
--- a/rome-modules/src/main/java/com/rometools/modules/atom/io/AtomLinkAttribute.java
+++ b/rome-modules/src/main/java/com/rometools/modules/atom/io/AtomLinkAttribute.java
@@ -15,7 +15,7 @@
  */
 package com.rometools.modules.atom.io;
 
-public interface AtomLinkAttribute {
+interface AtomLinkAttribute {
     String REL = "rel";
     String TYPE = "type";
     String HREF = "href";

--- a/rome-modules/src/main/java/com/rometools/modules/atom/io/AtomModuleGenerator.java
+++ b/rome-modules/src/main/java/com/rometools/modules/atom/io/AtomModuleGenerator.java
@@ -13,6 +13,7 @@
  * limitations under the License.
  *
  */
+
 package com.rometools.modules.atom.io;
 
 import com.rometools.modules.atom.modules.AtomLinkModule;
@@ -25,6 +26,7 @@ import org.jdom2.Namespace;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class AtomModuleGenerator implements ModuleGenerator {
@@ -52,46 +54,45 @@ public class AtomModuleGenerator implements ModuleGenerator {
     public void generate(Module module, Element element) {
         if (module instanceof AtomLinkModule) {
             AtomLinkModule m = (AtomLinkModule) module;
-            generateLinc(m.getLink(), element);
+            generateLinks(m.getLinks(), element);
         }
     }
 
-    private void generateLinc(Link link, Element element) {
-        if (link == null) {
-            return;
+    private void generateLinks(List<Link> links, Element element) {
+        for (Link link : links) {
+            Element linkElement = new Element("link", NS);
+
+            if (link.getHref() != null) {
+                Attribute href = new Attribute(AtomLinkAttribute.HREF, link.getHref());
+                linkElement.setAttribute(href);
+            }
+            if (link.getType() != null) {
+                Attribute type = new Attribute(AtomLinkAttribute.TYPE, link.getType());
+                linkElement.setAttribute(type);
+            }
+            if (link.getRel() != null) {
+                Attribute rel = new Attribute(AtomLinkAttribute.REL, link.getRel());
+                linkElement.setAttribute(rel);
+            }
+
+            if (link.getHreflang() != null) {
+                final Attribute hreflangAttribute = new Attribute(AtomLinkAttribute.HREF_LANG, link.getHreflang());
+                linkElement.setAttribute(hreflangAttribute);
+            }
+
+            if (link.getTitle() != null) {
+                final Attribute title = new Attribute(AtomLinkAttribute.TITLE, link.getTitle());
+                linkElement.setAttribute(title);
+            }
+
+            if (link.getLength() != 0) {
+                final Attribute lenght = new Attribute(AtomLinkAttribute.LENGTH, Long.toString(link.getLength()));
+                linkElement.setAttribute(lenght);
+            }
+
+            element.addContent(linkElement);
         }
 
-        Element linkElement = new Element("link", NS);
-
-        if (link.getHref() != null) {
-            Attribute href = new Attribute(AtomLinkAttribute.HREF, link.getHref());
-            linkElement.setAttribute(href);
-        }
-        if (link.getType() != null) {
-            Attribute type = new Attribute(AtomLinkAttribute.TYPE, link.getType());
-            linkElement.setAttribute(type);
-        }
-        if (link.getRel() != null) {
-            Attribute rel = new Attribute(AtomLinkAttribute.REL, link.getRel());
-            linkElement.setAttribute(rel);
-        }
-
-        if (link.getHreflang() != null) {
-            final Attribute hreflangAttribute = new Attribute(AtomLinkAttribute.HREF_LANG, link.getHreflang());
-            linkElement.setAttribute(hreflangAttribute);
-        }
-
-        if (link.getTitle() != null) {
-            final Attribute title = new Attribute(AtomLinkAttribute.TITLE, link.getTitle());
-            linkElement.setAttribute(title);
-        }
-
-        if (link.getLength() != 0) {
-            final Attribute lenght = new Attribute(AtomLinkAttribute.LENGTH, Long.toString(link.getLength()));
-            linkElement.setAttribute(lenght);
-        }
-
-        element.addContent(linkElement);
     }
 
 }

--- a/rome-modules/src/main/java/com/rometools/modules/atom/io/AtomModuleGenerator.java
+++ b/rome-modules/src/main/java/com/rometools/modules/atom/io/AtomModuleGenerator.java
@@ -58,39 +58,43 @@ public class AtomModuleGenerator implements ModuleGenerator {
         }
     }
 
+    private Element generateLink(Link link) {
+        Element linkElement = new Element("link", NS);
+
+        if (link.getHref() != null) {
+            Attribute href = new Attribute(AtomLinkAttribute.HREF, link.getHref());
+            linkElement.setAttribute(href);
+        }
+        if (link.getType() != null) {
+            Attribute type = new Attribute(AtomLinkAttribute.TYPE, link.getType());
+            linkElement.setAttribute(type);
+        }
+        if (link.getRel() != null) {
+            Attribute rel = new Attribute(AtomLinkAttribute.REL, link.getRel());
+            linkElement.setAttribute(rel);
+        }
+
+        if (link.getHreflang() != null) {
+            final Attribute hreflangAttribute = new Attribute(AtomLinkAttribute.HREF_LANG, link.getHreflang());
+            linkElement.setAttribute(hreflangAttribute);
+        }
+
+        if (link.getTitle() != null) {
+            final Attribute title = new Attribute(AtomLinkAttribute.TITLE, link.getTitle());
+            linkElement.setAttribute(title);
+        }
+
+        if (link.getLength() != 0) {
+            final Attribute length = new Attribute(AtomLinkAttribute.LENGTH, Long.toString(link.getLength()));
+            linkElement.setAttribute(length);
+        }
+
+        return linkElement;
+    }
+
     private void generateLinks(List<Link> links, Element element) {
         for (Link link : links) {
-            Element linkElement = new Element("link", NS);
-
-            if (link.getHref() != null) {
-                Attribute href = new Attribute(AtomLinkAttribute.HREF, link.getHref());
-                linkElement.setAttribute(href);
-            }
-            if (link.getType() != null) {
-                Attribute type = new Attribute(AtomLinkAttribute.TYPE, link.getType());
-                linkElement.setAttribute(type);
-            }
-            if (link.getRel() != null) {
-                Attribute rel = new Attribute(AtomLinkAttribute.REL, link.getRel());
-                linkElement.setAttribute(rel);
-            }
-
-            if (link.getHreflang() != null) {
-                final Attribute hreflangAttribute = new Attribute(AtomLinkAttribute.HREF_LANG, link.getHreflang());
-                linkElement.setAttribute(hreflangAttribute);
-            }
-
-            if (link.getTitle() != null) {
-                final Attribute title = new Attribute(AtomLinkAttribute.TITLE, link.getTitle());
-                linkElement.setAttribute(title);
-            }
-
-            if (link.getLength() != 0) {
-                final Attribute lenght = new Attribute(AtomLinkAttribute.LENGTH, Long.toString(link.getLength()));
-                linkElement.setAttribute(lenght);
-            }
-
-            element.addContent(linkElement);
+            element.addContent(generateLink(link));
         }
 
     }

--- a/rome-modules/src/main/java/com/rometools/modules/atom/io/AtomModuleParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/atom/io/AtomModuleParser.java
@@ -13,6 +13,7 @@
  * limitations under the License.
  *
  */
+
 package com.rometools.modules.atom.io;
 
 import com.rometools.modules.atom.modules.AtomLinkModule;
@@ -25,6 +26,8 @@ import org.jdom2.Attribute;
 import org.jdom2.Element;
 import org.jdom2.Namespace;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Locale;
 
 public class AtomModuleParser implements ModuleParser {
@@ -40,12 +43,14 @@ public class AtomModuleParser implements ModuleParser {
     public Module parse(Element element, Locale locale) {
         AtomLinkModuleImpl mod = new AtomLinkModuleImpl();
         if (element.getName().equals("channel") || element.getName().equals("item")) {
-            Element link = element.getChild("link", NS);
-            if (link != null) {
+            List<Element> links = element.getChildren("link", NS);
+            List<Link> result = new LinkedList<Link>();
+            for (Element link : links) {
                 Link l = parseLink(link);
-                mod.setLink(l);
-                return mod;
+                result.add(l);
             }
+            mod.setLinks(result);
+            return mod;
         }
         return null;
     }

--- a/rome-modules/src/main/java/com/rometools/modules/atom/modules/AtomLinkModule.java
+++ b/rome-modules/src/main/java/com/rometools/modules/atom/modules/AtomLinkModule.java
@@ -13,16 +13,19 @@
  * limitations under the License.
  *
  */
+
 package com.rometools.modules.atom.modules;
 
 import com.rometools.rome.feed.atom.Link;
 import com.rometools.rome.feed.module.Module;
 
+import java.util.List;
+
 public interface AtomLinkModule extends Module {
 
-    public static final String URI = "http://www.w3.org/2005/Atom";
+    String URI = "http://www.w3.org/2005/Atom";
 
-    public Link getLink();
+    List<Link> getLinks();
 
-    public void setLink(Link link);
+    void setLinks(List<Link> links);
 }

--- a/rome-modules/src/main/java/com/rometools/modules/atom/modules/AtomLinkModule.java
+++ b/rome-modules/src/main/java/com/rometools/modules/atom/modules/AtomLinkModule.java
@@ -26,6 +26,10 @@ public interface AtomLinkModule extends Module {
     String URI = "http://www.w3.org/2005/Atom";
 
     List<Link> getLinks();
+    @Deprecated
+    Link getLink();
 
     void setLinks(List<Link> links);
+    @Deprecated
+    void setLink(Link link);
 }

--- a/rome-modules/src/main/java/com/rometools/modules/atom/modules/AtomLinkModuleImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/atom/modules/AtomLinkModuleImpl.java
@@ -35,8 +35,21 @@ public class AtomLinkModuleImpl implements AtomLinkModule, Cloneable, Serializab
     }
 
     @Override
+    public Link getLink() {
+        if(links.size() > 0) {
+            return links.get(0);
+        }
+        return null;
+    }
+
+    @Override
     public void setLinks(List<Link> links) {
         this.links = links;
+    }
+
+    @Override
+    public void setLink(Link link) {
+        links.set(0, link);
     }
 
     @Override
@@ -61,14 +74,25 @@ public class AtomLinkModuleImpl implements AtomLinkModule, Cloneable, Serializab
             l.setHreflang(link.getHreflang());
             l.setTitle(link.getTitle());
             l.setLength(link.getLength());
-            links.add(l);
+            this.links.add(l);
         }
     }
 
     @Override
     public Object clone() {
         final AtomLinkModuleImpl m = new AtomLinkModuleImpl();
-        List<Link> result = links.subList(0, links.size());
+        List<Link> result = new LinkedList<Link>();
+        for(Link link : this.getLinks()) {
+            Link l = new Link();
+            l.setHref(link.getHref());
+            l.setType(link.getType());
+            l.setRel(link.getRel());
+            l.setHreflang(link.getHreflang());
+            l.setTitle(link.getTitle());
+            l.setLength(link.getLength());
+            result.add(l);
+        }
+        links.subList(0, links.size());
         m.setLinks(result);
         return m;
     }

--- a/rome-modules/src/main/java/com/rometools/modules/atom/modules/AtomLinkModuleImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/atom/modules/AtomLinkModuleImpl.java
@@ -13,6 +13,7 @@
  * limitations under the License.
  *
  */
+
 package com.rometools.modules.atom.modules;
 
 import com.rometools.rome.feed.CopyFrom;
@@ -21,19 +22,21 @@ import com.rometools.rome.feed.impl.EqualsBean;
 import com.rometools.rome.feed.impl.ToStringBean;
 
 import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
 
 public class AtomLinkModuleImpl implements AtomLinkModule, Cloneable, Serializable {
 
-    private Link link;
+    private List<Link> links = new LinkedList<Link>();
 
     @Override
-    public Link getLink() {
-        return link;
+    public List<Link> getLinks() {
+        return links;
     }
 
     @Override
-    public void setLink(Link link) {
-        this.link = link;
+    public void setLinks(List<Link> links) {
+        this.links = links;
     }
 
     @Override
@@ -49,8 +52,8 @@ public class AtomLinkModuleImpl implements AtomLinkModule, Cloneable, Serializab
     @Override
     public void copyFrom(CopyFrom obj) {
         AtomLinkModule other = (AtomLinkModule) obj;
-        Link link = other.getLink();
-        if (link != null) {
+        List<Link> links = other.getLinks();
+        for (Link link : links) {
             Link l = new Link();
             l.setHref(link.getHref());
             l.setType(link.getType());
@@ -58,23 +61,15 @@ public class AtomLinkModuleImpl implements AtomLinkModule, Cloneable, Serializab
             l.setHreflang(link.getHreflang());
             l.setTitle(link.getTitle());
             l.setLength(link.getLength());
-            setLink(l);
+            links.add(l);
         }
     }
 
     @Override
     public Object clone() {
         final AtomLinkModuleImpl m = new AtomLinkModuleImpl();
-        if (link != null) {
-            Link l = new Link();
-            l.setHref(link.getHref());
-            l.setType(link.getType());
-            l.setRel(link.getRel());
-            l.setHreflang(link.getHreflang());
-            l.setTitle(link.getTitle());
-            l.setLength(link.getLength());
-            m.setLink(l);
-        }
+        List<Link> result = links.subList(0, links.size());
+        m.setLinks(result);
         return m;
     }
 

--- a/rome-modules/src/test/java/com/rometools/modules/atom/AtomLinkTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/atom/AtomLinkTest.java
@@ -22,39 +22,22 @@ package com.rometools.modules.atom;
 import com.rometools.modules.AbstractTestCase;
 import com.rometools.modules.atom.io.AtomModuleGenerator;
 import com.rometools.modules.atom.modules.AtomLinkModule;
-import com.rometools.modules.sle.SimpleListExtension;
-import com.rometools.modules.sse.SSE091Generator;
-import com.rometools.modules.sse.modules.Conflict;
-import com.rometools.modules.sse.modules.History;
-import com.rometools.modules.sse.modules.SSEModule;
-import com.rometools.modules.sse.modules.Sync;
 import com.rometools.rome.feed.atom.Link;
-import com.rometools.rome.feed.rss.Item;
-import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
 import com.rometools.rome.io.SyndFeedInput;
-import com.rometools.rome.io.SyndFeedOutput;
-import com.rometools.rome.io.XmlReader;
-import com.rometools.rome.io.impl.DateParser;
 import junit.framework.Test;
 import junit.framework.TestSuite;
-import org.jdom2.Attribute;
-import org.jdom2.Content;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.input.SAXBuilder;
 
 import java.io.File;
-import java.net.URL;
-import java.util.*;
+import java.util.List;
 
 /**
  * Test to verify correctness of SSE subproject.
  */
 public class AtomLinkTest extends AbstractTestCase {
-    public static final String href = "http://test.com";
-    public static final String type = "application/rss+xml";
-    public static final String rel = "self";
+    public static final String[] href = {"http://test.com", "http://test.com/alt"};
+    public static final String[] type = {"application/rss+xml", "application/rss+xml"};
+    public static final String[] rel = {"self", "alternate"};
 
     public AtomLinkTest(final String testName) {
         super(testName);
@@ -85,11 +68,15 @@ public class AtomLinkTest extends AbstractTestCase {
         final SyndFeed feed = new SyndFeedInput().build(testdata);
 
         final AtomLinkModule atomLinkModule = (AtomLinkModule) feed.getModule(AtomLinkModule.URI);
-        Link link = atomLinkModule.getLink();
-
-        assertEquals(href, link.getHref());
-        assertEquals(rel, link.getRel());
-        assertEquals(type, link.getType());
+        List<Link> links = atomLinkModule.getLinks();
+        for (int i = 0; i < links.size(); i++) {
+            Link link = links.get(i);
+            assertEquals(href[i], link.getHref());
+            assertEquals(rel[i], link.getRel());
+            assertEquals(type[i], link.getType());
+        }
 
     }
+
 }
+

--- a/rome-modules/src/test/resources/atom/atom.xml
+++ b/rome-modules/src/test/resources/atom/atom.xml
@@ -5,5 +5,6 @@
         <link>http://test.com</link>
         <description>Test description</description>
         <atom:link href="http://test.com" type="application/rss+xml" rel="self" />
+        <atom:link href="http://test.com/alt" type="application/rss+xml" rel="alternate" />
     </channel>
 </rss>


### PR DESCRIPTION
I improved the Atom Module to work with several links, which is espacially useful for working with paged feeds like http://feeds.metaebene.me/lnp/mp3

See #301 for discussion. I Had git problems, so I had to make a new PR.