### PR TITLE
Set Atom feed icon when converting from SyndFeed

### DIFF
--- a/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom10.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom10.java
@@ -414,6 +414,11 @@ public class ConverterForAtom10 implements Converter {
             aFeed.setContributors(ConverterForAtom03.createAtomPersons(contributors));
         }
 
+        SyndImage image = syndFeed.getImage();
+        if (image != null) {
+            aFeed.setIcon(image.getUrl());
+        }
+
         aFeed.setRights(syndFeed.getCopyright());
 
         aFeed.setUpdated(syndFeed.getPublishedDate());

--- a/rome/src/test/resources/atom_1.0.xml
+++ b/rome/src/test/resources/atom_1.0.xml
@@ -17,6 +17,7 @@
     <uri>http://example.com</uri>
     <email>author1@example.com</email>
   </contributor>
+  <icon>http://example.com/icon</icon>
   <subtitle type="html">atom_1.0.feed.tagline</subtitle>
   <id>http://example.com/blog/atom_1.0.xml</id>
   <generator uri="http://example.com/test">atom_1.0.feed.generator</generator>


### PR DESCRIPTION
We currently neglect the feed icon when converting from a SyndFeed to an Atom Feed. This PR remedies this.