### PR TITLE
Fixed permaLink default value, should be set to 'true' per the spec

### DIFF
--- a/rome/src/main/java/com/rometools/rome/feed/rss/Guid.java
+++ b/rome/src/main/java/com/rometools/rome/feed/rss/Guid.java
@@ -27,7 +27,7 @@ import com.rometools.rome.feed.impl.ObjectBean;
 public class Guid implements Cloneable, Serializable {
     private static final long serialVersionUID = 1L;
     private final ObjectBean objBean;
-    private boolean permaLink;
+    private boolean permaLink = true;
     private String value;
 
     public Guid() {


### PR DESCRIPTION
Fixed permaLink default value, should be set to 'true' per the spec: http://cyber.harvard.edu/rss/rss.html