### PR TITLE
support for custom http request headers on XmlReader added (#346)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,11 @@
                 <artifactId>oauth</artifactId>
                 <version>20100527</version>
             </dependency>
+            <dependency>
+                <groupId>com.github.tomakehurst</groupId>
+                <artifactId>wiremock</artifactId>
+                <version>1.58</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/rome/pom.xml
+++ b/rome/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/rome/src/main/java/com/rometools/rome/feed/synd/SyndFeed.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/SyndFeed.java
@@ -424,6 +424,24 @@ public interface SyndFeed extends Cloneable, CopyFrom, Extendable {
     void setImage(SyndImage image);
 
     /**
+     * Returns the feed icon.
+     * <p>
+     *
+     * @return the feed icon, <b>null</b> if none.
+     *
+     */
+    SyndImage getIcon();
+
+    /**
+     * Sets the feed icon.
+     * <p>
+     *
+     * @param icon the feed icon to set, <b>null</b> if none.
+     *
+     */
+    void setIcon(SyndImage icon);
+
+    /**
      * Returns the feed categories.
      * <p>
      * This method is a convenience method, it maps to the Dublin Core module subjects.

--- a/rome/src/main/java/com/rometools/rome/feed/synd/SyndFeedImpl.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/SyndFeedImpl.java
@@ -67,6 +67,7 @@ public class SyndFeedImpl implements Serializable, SyndFeed {
     private String generator;
     private String styleSheet;
     private List<SyndLink> links;
+    private SyndImage icon;
     private SyndImage image;
     private List<SyndEntry> entries;
     private List<Module> modules;
@@ -610,6 +611,30 @@ public class SyndFeedImpl implements Serializable, SyndFeed {
     @Override
     public void setCopyright(final String copyright) {
         getDCModule().setRights(copyright);
+    }
+
+    /**
+     * Returns the feed icon.
+     * <p>
+     *
+     * @return the feed icon, <b>null</b> if none.
+     *
+     */
+    @Override
+    public SyndImage getIcon() {
+        return icon;
+    }
+
+    /**
+     * Sets the feed icon.
+     * <p>
+     *
+     * @param image the feed icon to set, <b>null</b> if none.
+     *
+     */
+    @Override
+    public void setIcon(final SyndImage icon) {
+        this.icon = icon;
     }
 
     /**

--- a/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom10.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom10.java
@@ -82,16 +82,17 @@ public class ConverterForAtom10 implements Converter {
         syndFeed.setStyleSheet(aFeed.getStyleSheet());
 
         final String logo = aFeed.getLogo();
-        final String icon = aFeed.getIcon();
-
         if (logo != null) {
             final SyndImage image = new SyndImageImpl();
             image.setUrl(logo);
             syndFeed.setImage(image);
-        } else if (icon != null) {
+        }
+
+        final String icon = aFeed.getIcon();
+        if (icon != null) {
             final SyndImage image = new SyndImageImpl();
             image.setUrl(icon);
-            syndFeed.setImage(image);
+            syndFeed.setIcon(image);
         }
 
         syndFeed.setUri(aFeed.getId());
@@ -416,7 +417,12 @@ public class ConverterForAtom10 implements Converter {
 
         SyndImage image = syndFeed.getImage();
         if (image != null) {
-            aFeed.setIcon(image.getUrl());
+            aFeed.setLogo(image.getUrl());
+        }
+
+        final SyndImage icon = syndFeed.getIcon();
+        if (icon != null) {
+            aFeed.setIcon(icon.getUrl());
         }
 
         aFeed.setRights(syndFeed.getCopyright());

--- a/rome/src/test/java/com/rometools/rome/io/XmLReaderHttpHeaderTest.java
+++ b/rome/src/test/java/com/rometools/rome/io/XmLReaderHttpHeaderTest.java
@@ -1,0 +1,45 @@
+package com.rometools.rome.io;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+public class XmLReaderHttpHeaderTest {
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
+
+    @Before
+    public void init() {
+        stubFor(get(urlEqualTo("/test")).willReturn(aResponse().withStatus(200).withHeader("Content-Type", "text/xml")
+                .withBody("<?xml version=\"1.0\" encoding=\"utf-8\"?><rss version=\"2.0\"><channel/></rss>")));
+    }
+
+    @Test
+    public void testUrlWithoutHeaders() throws IOException {
+        final URL url = new URL("http://localhost:" + wireMockRule.port() + "/test");
+        final XmlReader xmlReader = new XmlReader(url);
+        xmlReader.close();
+        verify(getRequestedFor(urlEqualTo("/test")).withHeader("User-Agent", matching("(?i)rome.*")));
+    }
+
+    @Test
+    public void testUrlWithHeaders() throws IOException {
+        final Map<String, String> headers = new HashMap<String, String>();
+        headers.put("User-Agent", "abcd");
+        headers.put("Accept", "efgh");
+        final URL url = new URL("http://localhost:" + wireMockRule.port() + "/test");
+        final XmlReader xmlReader = new XmlReader(url, headers);
+        xmlReader.close();
+        verify(getRequestedFor(urlEqualTo("/test")).withHeader("User-Agent", equalTo("abcd")).withHeader("Accept", equalTo("efgh")));
+    }
+}

--- a/rome/src/test/resources/atom_1.0.xml
+++ b/rome/src/test/resources/atom_1.0.xml
@@ -18,6 +18,7 @@
     <email>author1@example.com</email>
   </contributor>
   <icon>http://example.com/icon</icon>
+  <logo>http://example.com/logo</logo>
   <subtitle type="html">atom_1.0.feed.tagline</subtitle>
   <id>http://example.com/blog/atom_1.0.xml</id>
   <generator uri="http://example.com/test">atom_1.0.feed.generator</generator>


### PR DESCRIPTION
Because of #346, I've extended XmlReader to set custom http request headers more easily, not sure if it should be added to core?