### PR TITLE
Update iTunes module for iOS 11 new podcast's rss specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
+  - openjdk7
 script: mvn verify

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformation.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformation.java
@@ -45,4 +45,38 @@ public interface EntryInformation extends ITunes {
     public Integer getOrder();
 
     public void setOrder(Integer order);
+
+    /**
+     * Get the encoded episode notes
+     * @see #setEncoded(String) setEncoded(encodedNotes) for details
+     */
+    public String getEncoded();
+
+    /**
+     * Set the episode notes (allow basic HTML tags such as &lt;p&gt;,&lt;ol&gt;,&lt;ul&gt;,&lt;a&gt;,&lt;em&gt;,&lt;i&gt; and &lt;b&gt;. See the <a href="http://podcasts.apple.com/resources/spec/ApplePodcastsSpecUpdatesiOS11.pdf">new spec by Apple</a> for details.
+     * @param encodedNotes
+     */
+    public void setEncoded(String encodedNotes);
+
+    /**
+     * Get the episode type
+     * @see #setEpisodeType(String) setEpisodeType(episodeType) for details
+     */
+    public String getEpisodeType();
+
+    /**
+     * Set the episode type to one of full (default), trailer or bonus. See the <a href="http://podcasts.apple.com/resources/spec/ApplePodcastsSpecUpdatesiOS11.pdf">new spec by Apple</a> for details.
+     * @param episodeType
+     */
+    public void setEpisodeType(String episodeType);
+
+    public Integer getSeason();
+
+    public void setSeason(Integer season);
+
+    public Integer getEpisode();
+
+    public void setEpisode(Integer episode);
+
+
 }

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformation.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformation.java
@@ -47,18 +47,6 @@ public interface EntryInformation extends ITunes {
     public void setOrder(Integer order);
 
     /**
-     * Get the encoded episode notes
-     * @see #setEncoded(String) setEncoded(encodedNotes) for details
-     */
-    public String getEncoded();
-
-    /**
-     * Set the episode notes (allow basic HTML tags such as &lt;p&gt;,&lt;ol&gt;,&lt;ul&gt;,&lt;a&gt;,&lt;em&gt;,&lt;i&gt; and &lt;b&gt;. See the <a href="http://podcasts.apple.com/resources/spec/ApplePodcastsSpecUpdatesiOS11.pdf">new spec by Apple</a> for details.
-     * @param encodedNotes
-     */
-    public void setEncoded(String encodedNotes);
-
-    /**
      * Get the episode type
      * @see #setEpisodeType(String) setEpisodeType(episodeType) for details
      */

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformationImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformationImpl.java
@@ -37,7 +37,6 @@ public class EntryInformationImpl extends AbstractITunesObject implements EntryI
     private Duration duration;
     private boolean closedCaptioned;
     private Integer order;
-    private String encodedNotes;
     private String episodeType;
     private Integer season;
     private Integer episode;
@@ -84,22 +83,6 @@ public class EntryInformationImpl extends AbstractITunesObject implements EntryI
     public void setOrder(Integer order) {
         this.order = order;
     }
-
-    /**
-     * Get the encoded episode notes
-     *
-     * @see #setEncoded(String) setEncoded(encodedNotes) for details
-     */
-    @Override
-    public String getEncoded() { return encodedNotes; }
-
-    /**
-     * Set the episode notes (allow basic HTML tags such as &lt;p&gt;,&lt;ol&gt;,&lt;ul&gt;,&lt;a&gt;,&lt;em&gt;,&lt;i&gt; and &lt;b&gt;. See the <a href="http://podcasts.apple.com/resources/spec/ApplePodcastsSpecUpdatesiOS11.pdf">new spec by Apple</a> for details.
-     *
-     * @param encodedNotes
-     */
-    @Override
-    public void setEncoded(String encodedNotes) { this.encodedNotes = encodedNotes; }
 
     /**
      * Get the episode type
@@ -160,7 +143,6 @@ public class EntryInformationImpl extends AbstractITunesObject implements EntryI
 
         setSubtitle(info.getSubtitle());
         setSummary(info.getSummary());
-        setEncoded(info.getEncoded());
         setClosedCaptioned(info.getClosedCaptioned());
         setOrder(info.getOrder());
         setEpisodeType(info.getEpisodeType());
@@ -196,8 +178,6 @@ public class EntryInformationImpl extends AbstractITunesObject implements EntryI
         sb.append(getEpisode());
         sb.append(" episodeType: ");
         sb.append(getEpisodeType());
-        sb.append(" encoded: ");
-        sb.append(getEncoded());
         sb.append("]");
         sb.append(super.toString());
 

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformationImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformationImpl.java
@@ -37,6 +37,10 @@ public class EntryInformationImpl extends AbstractITunesObject implements EntryI
     private Duration duration;
     private boolean closedCaptioned;
     private Integer order;
+    private String encodedNotes;
+    private String episodeType;
+    private Integer season;
+    private Integer episode;
 
     public EntryInformationImpl() {
     }
@@ -82,6 +86,50 @@ public class EntryInformationImpl extends AbstractITunesObject implements EntryI
     }
 
     /**
+     * Get the encoded episode notes
+     *
+     * @see #setEncoded(String) setEncoded(encodedNotes) for details
+     */
+    @Override
+    public String getEncoded() { return encodedNotes; }
+
+    /**
+     * Set the episode notes (allow basic HTML tags such as &lt;p&gt;,&lt;ol&gt;,&lt;ul&gt;,&lt;a&gt;,&lt;em&gt;,&lt;i&gt; and &lt;b&gt;. See the <a href="http://podcasts.apple.com/resources/spec/ApplePodcastsSpecUpdatesiOS11.pdf">new spec by Apple</a> for details.
+     *
+     * @param encodedNotes
+     */
+    @Override
+    public void setEncoded(String encodedNotes) { this.encodedNotes = encodedNotes; }
+
+    /**
+     * Get the episode type
+     *
+     * @see #setEpisodeType(String) setEpisodeType(episodeType) for details
+     */
+    @Override
+    public String getEpisodeType() { return episodeType; }
+
+    /**
+     * Set the episode type to one of full (default), trailer or bonus. See see the <a href="http://podcasts.apple.com/resources/spec/ApplePodcastsSpecUpdatesiOS11.pdf">new spec by Apple</a> for details.
+     *
+     * @param episodeType
+     */
+    @Override
+    public void setEpisodeType(String episodeType) { this.episodeType = episodeType; }
+
+    @Override
+    public Integer getSeason() { return season; }
+
+    @Override
+    public void setSeason(Integer season) { this.season = season; }
+
+    @Override
+    public Integer getEpisode() { return episode; }
+
+    @Override
+    public void setEpisode(Integer episode) { this.episode = episode; }
+
+    /**
      * Defined by the ROME module API
      *
      * @param obj Object to copy from
@@ -112,8 +160,12 @@ public class EntryInformationImpl extends AbstractITunesObject implements EntryI
 
         setSubtitle(info.getSubtitle());
         setSummary(info.getSummary());
+        setEncoded(info.getEncoded());
         setClosedCaptioned(info.getClosedCaptioned());
         setOrder(info.getOrder());
+        setEpisodeType(info.getEpisodeType());
+        setSeason(info.getSeason());
+        setEpisode(info.getEpisode());
     }
 
     /**
@@ -138,6 +190,14 @@ public class EntryInformationImpl extends AbstractITunesObject implements EntryI
         sb.append(getClosedCaptioned());
         sb.append(" order: ");
         sb.append(getOrder());
+        sb.append(" season: ");
+        sb.append(getSeason());
+        sb.append(" episode: ");
+        sb.append(getEpisode());
+        sb.append(" episodeType: ");
+        sb.append(getEpisodeType());
+        sb.append(" encoded: ");
+        sb.append(getEncoded());
         sb.append("]");
         sb.append(super.toString());
 

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/FeedInformation.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/FeedInformation.java
@@ -75,4 +75,19 @@ public interface FeedInformation extends ITunes {
      * @return Returns the owner name for the feed
      */
     public String getOwnerName();
+
+    /**
+     * Set the type of podcast to either Episodic (original type of podcasts) or Serial (should be consumed from oldest to newest)
+     * @see #getType() getType() for more details
+     * @param type  the type (Either 'serial' or 'episodic')
+     */
+    public void setType(String type);
+
+    /**
+     * Return the type of podcast (either Episodic or Serial) as introduced in the new Apple Podcast spec for iOS 11.
+     * For more information see the <a href="http://podcasts.apple.com/resources/spec/ApplePodcastsSpecUpdatesiOS11.pdf">new spec by Apple</a>
+     * @return either 'episodic' (old school podcasts) or 'serial' (should be listened to from oldest to newest)
+     */
+    public String getType();
+
 }

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/FeedInformationImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/FeedInformationImpl.java
@@ -41,6 +41,7 @@ public class FeedInformationImpl extends AbstractITunesObject implements FeedInf
     private List<Category> categories;
     private boolean complete;
     private String newFeedUrl;
+    private String type;
 
     public FeedInformationImpl() {
     }
@@ -126,6 +127,22 @@ public class FeedInformationImpl extends AbstractITunesObject implements FeedInf
     }
 
     /**
+     * Set the type of podcast to either Episodic (original type of podcasts) or Serial (should be consumed from oldest to newest)
+     * @see #getType() getType() for more details
+     * @param type  the type (Either 'serial' or 'episodic')
+     */
+    @Override
+    public void setType(final String type) { this.type = type; }
+
+    /**
+     * Return the type of podcast (either Episodic or Serial) as introduced in the new Apple Podcast spec for iOS 11.
+     * For more information see the <a href="http://podcasts.apple.com/resources/spec/ApplePodcastsSpecUpdatesiOS11.pdf">new spec by Apple</a>
+     * @return either 'episodic' (old school podcasts) or 'serial' (should be listened to from oldest to newest)
+     */
+    @Override
+    public String getType() { return type; }
+
+    /**
      * Required by the ROME API
      *
      * @param obj object to copy property values from
@@ -161,6 +178,7 @@ public class FeedInformationImpl extends AbstractITunesObject implements FeedInf
         setOwnerName(info.getOwnerName());
         setSubtitle(info.getSubtitle());
         setSummary(info.getSummary());
+        setType(info.getType());
     }
 
     /**
@@ -189,6 +207,8 @@ public class FeedInformationImpl extends AbstractITunesObject implements FeedInf
         sb.append(getComplete());
         sb.append(" newFeedUrl: ");
         sb.append(getNewFeedUrl());
+        sb.append(" type: ");
+        sb.append(getType());
         sb.append("]");
         sb.append(super.toString());
 

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesGenerator.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesGenerator.java
@@ -84,6 +84,10 @@ public class ITunesGenerator implements ModuleGenerator {
                 element.addContent(category);
             }
 
+            if (info.getType() != null) {
+                element.addContent(generateSimpleElement("type",info.getType()));
+            }
+
             if (info.getComplete()) {
                 element.addContent(generateSimpleElement("complete", "yes"));
             }
@@ -103,6 +107,18 @@ public class ITunesGenerator implements ModuleGenerator {
             }
             if (info.getOrder() != null) {
                 element.addContent(generateSimpleElement("order", info.getOrder().toString()));
+            }
+            if (info.getEncoded() != null) {
+                element.addContent(generateSimpleElement("encoded", info.getEncoded()));
+            }
+            if (info.getEpisodeType() != null) {
+                element.addContent(generateSimpleElement("episodeType", info.getEpisodeType()));
+            }
+            if (info.getSeason() != null && info.getSeason() > 0) {
+                element.addContent(generateSimpleElement("season", info.getSeason().toString()));
+            }
+            if (info.getEpisode() != null && info.getEpisode() > 0) {
+                element.addContent(generateSimpleElement("episode", info.getEpisode().toString()));
             }
         }
 

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesGenerator.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesGenerator.java
@@ -108,9 +108,6 @@ public class ITunesGenerator implements ModuleGenerator {
             if (info.getOrder() != null) {
                 element.addContent(generateSimpleElement("order", info.getOrder().toString()));
             }
-            if (info.getEncoded() != null) {
-                element.addContent(generateSimpleElement("encoded", info.getEncoded()));
-            }
             if (info.getEpisodeType() != null) {
                 element.addContent(generateSimpleElement("episodeType", info.getEpisodeType()));
             }

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
@@ -163,12 +163,6 @@ public class ITunesParser implements ModuleParser {
             if (episodeType != null && episodeType.getValue() != null) {
                 entryInfo.setEpisodeType(episodeType.getTextTrim());
             }
-
-            final Element encoded = element.getChild("encoded", ns);
-
-            if (encoded != null && encoded.getValue() != null) {
-                entryInfo.setEncoded(encoded.getText());
-            }
         }
         if (module != null) {
             // All these are common to both Channel and Item

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
@@ -109,6 +109,11 @@ public class ITunesParser implements ModuleParser {
                 feedInfo.setNewFeedUrl(newFeedUrl.getTextTrim());
             }
 
+            final Element type = element.getChild("type", ns);
+            if (type != null) {
+                feedInfo.setType(type.getTextTrim());
+            }
+
         } else if (element.getName().equals("item")) {
             final EntryInformationImpl entryInfo = new EntryInformationImpl();
             module = entryInfo;
@@ -137,6 +142,32 @@ public class ITunesParser implements ModuleParser {
             if (order != null && order.getValue() != null) {
                 final Integer o = Integer.valueOf(order.getValue().trim());
                 entryInfo.setOrder(o);
+            }
+
+            final Element season = element.getChild("season", ns);
+
+            if (season != null && season.getValue() != null) {
+                final Integer o = Integer.valueOf(season.getValue().trim());
+                entryInfo.setSeason(o);
+            }
+
+            final Element episode = element.getChild("episode", ns);
+
+            if (episode != null && episode.getValue() != null) {
+                final Integer o = Integer.valueOf(episode.getValue().trim());
+                entryInfo.setEpisode(o);
+            }
+
+            final Element episodeType = element.getChild("episodeType", ns);
+
+            if (episodeType != null && episodeType.getValue() != null) {
+                entryInfo.setEpisodeType(episodeType.getTextTrim());
+            }
+
+            final Element encoded = element.getChild("encoded", ns);
+
+            if (encoded != null && encoded.getValue() != null) {
+                entryInfo.setEncoded(encoded.getText());
             }
         }
         if (module != null) {

--- a/rome-modules/src/test/java/com/rometools/modules/itunes/ITunesGeneratorTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/itunes/ITunesGeneratorTest.java
@@ -107,6 +107,7 @@ public class ITunesGeneratorTest extends AbstractTestCase {
         fi.setOwnerName("sales.com");
         fi.getCategories().add(new Category("Shopping"));
         fi.setOwnerEmailAddress("patti@sales.com");
+        fi.setType("serial");
         feed.getModules().add(fi);
 
         final SyndFeedOutput output = new SyndFeedOutput();

--- a/rome-modules/src/test/resources/itunes/leshow.xml
+++ b/rome-modules/src/test/resources/itunes/leshow.xml
@@ -67,7 +67,6 @@
 	    <itunes:duration>46:34</itunes:duration>
 	
     <itunes:keywords></itunes:keywords>
-    <itunes:encoded><![CDATA[show notes with <b>bold</b> text.]]></itunes:encoded>
     <itunes:season>1</itunes:season>
     <itunes:episode>1</itunes:episode>
     <itunes:episodeType>full</itunes:episodeType>

--- a/rome-modules/src/test/resources/itunes/leshow.xml
+++ b/rome-modules/src/test/resources/itunes/leshow.xml
@@ -7,6 +7,7 @@
         <description>A weekly, hour-long romp through the worlds of media, politics, sports and show business, leavened with an eclectic mix of mysterious music, hosted by Harry Shearer.</description>
         <itunes:subtitle>An hour&#39;s worth of Harry Shearer</itunes:subtitle>
         <itunes:summary>A weekly, hour-long romp through the worlds of media, politics, sports and show business, leavened with an eclectic mix of mysterious music, hosted by Harry Shearer.</itunes:summary>
+        <itunes:type>serial</itunes:type>
         <language>en</language>
         
             <copyright>KCRW 2005</copyright>
@@ -65,7 +66,11 @@
 	
 	    <itunes:duration>46:34</itunes:duration>
 	
-    <itunes:keywords></itunes:keywords>  
+    <itunes:keywords></itunes:keywords>
+    <itunes:encoded><![CDATA[show notes with <b>bold</b> text.]]></itunes:encoded>
+    <itunes:season>1</itunes:season>
+    <itunes:episode>1</itunes:episode>
+    <itunes:episodeType>full</itunes:episodeType>
 </item>
 
         
@@ -103,7 +108,10 @@
 	
 	    <itunes:duration>44:00</itunes:duration>
 	
-    <itunes:keywords></itunes:keywords>  
+    <itunes:keywords></itunes:keywords>
+    <itunes:season>1</itunes:season>
+    <itunes:episode>2</itunes:episode>
+    <itunes:episodeType>trailer</itunes:episodeType>
 </item>
 
         
@@ -141,7 +149,10 @@
 	
 	    <itunes:duration>48:33</itunes:duration>
 	
-    <itunes:keywords></itunes:keywords>  
+    <itunes:keywords></itunes:keywords>
+    <itunes:season>1</itunes:season>
+    <itunes:episode>2</itunes:episode>
+    <itunes:episodeType>bonus</itunes:episodeType>
 </item>
 
         

--- a/rome-modules/src/test/resources/xml/leshow.xml
+++ b/rome-modules/src/test/resources/xml/leshow.xml
@@ -9,6 +9,7 @@
         <itunes:summary>A weekly, hour-long romp through the worlds of media, politics, sports and show business, leavened with an eclectic mix of mysterious music, hosted by Harry Shearer.</itunes:summary>
         <itunes:complete>yes</itunes:complete>
         <itunes:new-feed-url>http://example.org</itunes:new-feed-url>
+        <itunes:type>serial</itunes:type>
         <language>en</language>
         
             <copyright>KCRW 2005</copyright>
@@ -71,10 +72,13 @@
     <itunes:isClosedCaptioned>yes</itunes:isClosedCaptioned>
     <itunes:order>2</itunes:order>
     <itunes:image href="http://example.org/image.png"></itunes:image>
+    <itunes:encoded><![CDATA[show notes with <b>bold</b> text.]]></itunes:encoded>
+    <itunes:season>1</itunes:season>
+    <itunes:episode>1</itunes:episode>
+    <itunes:episodeType>full</itunes:episodeType>
 </item>
 
-        
-            <item>
+<item>
     <title>le Show</title>
     <itunes:author>Harry Shearer</itunes:author>
     <description>
@@ -109,6 +113,9 @@
 	    <itunes:duration>44:00</itunes:duration>
 	
     <itunes:keywords></itunes:keywords>  
+    <itunes:season>1</itunes:season>
+    <itunes:episode>2</itunes:episode>
+    <itunes:episodeType>trailer</itunes:episodeType>
 </item>
 
         
@@ -147,6 +154,9 @@
 	    <itunes:duration>48:33</itunes:duration>
 	
     <itunes:keywords></itunes:keywords>  
+    <itunes:season>1</itunes:season>
+    <itunes:episode>2</itunes:episode>
+    <itunes:episodeType>bonus</itunes:episodeType>
 </item>
 
         

--- a/rome-modules/src/test/resources/xml/leshow.xml
+++ b/rome-modules/src/test/resources/xml/leshow.xml
@@ -72,7 +72,6 @@
     <itunes:isClosedCaptioned>yes</itunes:isClosedCaptioned>
     <itunes:order>2</itunes:order>
     <itunes:image href="http://example.org/image.png"></itunes:image>
-    <itunes:encoded><![CDATA[show notes with <b>bold</b> text.]]></itunes:encoded>
     <itunes:season>1</itunes:season>
     <itunes:episode>1</itunes:episode>
     <itunes:episodeType>full</itunes:episodeType>


### PR DESCRIPTION
Update iTunes module for iOS 11 new podcast's rss specs

Apple released new guidlines for the itunes RSS spec for podcasts: http://podcasts.apple.com/resources/spec/ApplePodcastsSpecUpdatesiOS11.pdf

The specific technical changes are the addition of the following attributes:

Channel level: The following was added:

itunes:type :: type of podcast 'episodic' (default)  or 'serial'.

Item level: The following was added:

itunes:season :: a non-zero integer number for a season identifier
itunes:episode :: a non-zero integer episode number within the season
itunes:episodeType :: one of 'full' (default) 'bonus' or 'trailer'
itunes:encoded :: show notes with basic HTML formatting

All new values are optional.