### PR TITLE
Uses Currency/BigDecimal for the Price tag in Media RSS

### DIFF
--- a/rome-modules/src/main/java/com/rometools/modules/mediarss/io/MediaModuleParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/mediarss/io/MediaModuleParser.java
@@ -25,12 +25,9 @@ import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.StringTokenizer;
 
 import org.jdom2.Element;
 import org.jdom2.Namespace;
@@ -465,8 +462,16 @@ public class MediaModuleParser implements ModuleParser {
         for (int i = 0; i < priceElements.size(); i++) {
             final Element priceElement = priceElements.get(i);
             prices[i] = new Price();
-            prices[i].setCurrency(priceElement.getAttributeValue("currency"));
-            prices[i].setPrice(Doubles.parse(priceElement.getAttributeValue("price")));
+            try {
+                prices[i].setCurrency(Currency.getInstance(priceElement.getAttributeValue("currency")));
+            } catch (RuntimeException ex) {
+                LOG.warn("Exception parsing currency code", ex);
+            }
+            try {
+                prices[i].setPrice(new BigDecimal(priceElement.getAttributeValue("price")));
+            } catch (NumberFormatException ex) {
+                LOG.warn("Exception parsing price amount", ex);
+            }
             if (priceElement.getAttributeValue("type") != null) {
                 prices[i].setType(Price.Type.valueOf(priceElement.getAttributeValue("type").toUpperCase()));
             }

--- a/rome-modules/src/main/java/com/rometools/modules/mediarss/types/Price.java
+++ b/rome-modules/src/main/java/com/rometools/modules/mediarss/types/Price.java
@@ -20,7 +20,9 @@
 package com.rometools.modules.mediarss.types;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.net.URL;
+import java.util.Currency;
 
 /**
  * Optional tag to include pricing information about a media object.
@@ -40,8 +42,8 @@ public class Price implements Serializable {
     }
 
     private Type type;
-    private Double price;
-    private String currency;
+    private BigDecimal price;
+    private Currency currency;
     private URL info;
 
     /**
@@ -69,7 +71,7 @@ public class Price implements Serializable {
      * 
      * @return the price
      */
-    public Double getPrice() {
+    public BigDecimal getPrice() {
         return price;
     }
 
@@ -80,7 +82,7 @@ public class Price implements Serializable {
      * 
      * @param price the price
      */
-    public void setPrice(final Double price) {
+    public void setPrice(final BigDecimal price) {
         this.price = price;
     }
 
@@ -89,7 +91,7 @@ public class Price implements Serializable {
      * 
      * @return ISO 4217 currency code
      */
-    public String getCurrency() {
+    public Currency getCurrency() {
         return currency;
     }
 
@@ -98,7 +100,7 @@ public class Price implements Serializable {
      * 
      * @param currency ISO 4217 currency code
      */
-    public void setCurrency(final String currency) {
+    public void setCurrency(final Currency currency) {
         this.currency = currency;
     }
 


### PR DESCRIPTION
_Price_ tag in **Media RSS** module was implemented using a `java.lang.String` for the currency and `java.lang.Double` for the price value, which is not recommended for monetary data (causes rounding error). This fix refactors the _Price_ tag to use `java.util.Currency` for the currency code (as recommended by the ISO 4217) and `java.math.BigDecimal` for the price value.