### PR TITLE
Fix javadoc parameter name in SyndFeedImpl

### DIFF
--- a/rome/src/main/java/com/rometools/rome/feed/synd/SyndEntryImpl.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/SyndEntryImpl.java
@@ -90,7 +90,6 @@ public class SyndEntryImpl implements Serializable, SyndEntry {
         IGNORE_PROPERTIES.add("author");
 
         final Map<String, Class<?>> basePropInterfaceMap = new HashMap<String, Class<?>>();
-        basePropInterfaceMap.put("uri", String.class);
         basePropInterfaceMap.put("title", String.class);
         basePropInterfaceMap.put("link", String.class);
         basePropInterfaceMap.put("uri", String.class);

--- a/rome/src/main/java/com/rometools/rome/feed/synd/SyndFeed.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/SyndFeed.java
@@ -566,7 +566,7 @@ public interface SyndFeed extends Cloneable, CopyFrom, Extendable {
      * This tag should contain a URL that references a description of the channel.
      *
      * @since 2.0.0
-     * @param channel description URL
+     * @param docs description URL
      */
     public void setDocs(String docs);
 
@@ -582,7 +582,7 @@ public interface SyndFeed extends Cloneable, CopyFrom, Extendable {
      * A string indicating the program used to generate the channel.
      *
      * @since 2.0.0
-     * @param string indicating the program
+     * @param generator indicating the program
      */
     public void setGenerator(String generator);
 

--- a/rome/src/main/java/com/rometools/rome/feed/synd/SyndFeedImpl.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/SyndFeedImpl.java
@@ -629,7 +629,7 @@ public class SyndFeedImpl implements Serializable, SyndFeed {
      * Sets the feed icon.
      * <p>
      *
-     * @param image the feed icon to set, <b>null</b> if none.
+     * @param icon the feed icon to set, <b>null</b> if none.
      *
      */
     @Override


### PR DESCRIPTION
And remove the duplicate call to `Map#put` in SyndEntryImpl.
(Trivial fixes)