### PR TITLE
Support all possible values of itunes:explicit

### DIFF
--- a/rome-modules/src/main/java/com/rometools/modules/itunes/AbstractITunesObject.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/AbstractITunesObject.java
@@ -45,7 +45,7 @@ public abstract class AbstractITunesObject implements ITunes, java.lang.Cloneabl
     public static final String PREFIX = "itunes";
     private String author;
     private boolean block;
-    private boolean explicit;
+    private Boolean explicit;
     private URL image;
     private String[] keywords;
     private String subtitle;
@@ -126,6 +126,11 @@ public abstract class AbstractITunesObject implements ITunes, java.lang.Cloneabl
      */
     @Override
     public boolean getExplicit() {
+        return explicit != null ? explicit : false;
+    }
+
+    @Override
+    public Boolean getExplicitNullable() {
         return explicit;
     }
 
@@ -136,6 +141,11 @@ public abstract class AbstractITunesObject implements ITunes, java.lang.Cloneabl
      */
     @Override
     public void setExplicit(final boolean explicit) {
+        this.explicit = explicit;
+    }
+
+    @Override
+    public void setExplicitNullable(final Boolean explicit) {
         this.explicit = explicit;
     }
 
@@ -221,7 +231,7 @@ public abstract class AbstractITunesObject implements ITunes, java.lang.Cloneabl
         sb.append(" Block: ");
         sb.append(getBlock());
         sb.append(" Explicit: ");
-        sb.append(getExplicit());
+        sb.append(getExplicitNullable());
         sb.append(" Image: ");
         sb.append(getImage());
         sb.append(" Keywords: ");

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformationImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformationImpl.java
@@ -127,7 +127,7 @@ public class EntryInformationImpl extends AbstractITunesObject implements EntryI
             setDuration(new Duration(info.getDuration().getMilliseconds()));
         }
 
-        setExplicit(info.getExplicit());
+        setExplicitNullable(info.getExplicitNullable());
 
         try {
             if (info.getImage() != null) {

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/FeedInformationImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/FeedInformationImpl.java
@@ -160,7 +160,7 @@ public class FeedInformationImpl extends AbstractITunesObject implements FeedInf
 
         setComplete(info.getComplete());
         setNewFeedUrl(info.getNewFeedUrl());
-        setExplicit(info.getExplicit());
+        setExplicitNullable(info.getExplicitNullable());
 
         try {
             if (info.getImage() != null) {

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/ITunes.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/ITunes.java
@@ -62,12 +62,16 @@ public interface ITunes extends Module {
      */
     public boolean getExplicit();
 
+    public Boolean getExplicitNullable();
+
     /**
      * Boolean as to whether this feed or entry contains adult content
      *
      * @param explicit Boolean as to whether this feed or entry contains adult content
      */
     public void setExplicit(boolean explicit);
+
+    public void setExplicitNullable(Boolean explicit);
 
     public URL getImage();
 

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesGenerator.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesGenerator.java
@@ -128,10 +128,12 @@ public class ITunesGenerator implements ModuleGenerator {
             element.addContent(generateSimpleElement("block", ""));
         }
 
-        if (itunes.getExplicit()) {
-            element.addContent(generateSimpleElement("explicit", "yes"));
-        } else {
-            element.addContent(generateSimpleElement("explicit", "no"));
+        if (itunes.getExplicitNullable() != null) {
+            if (itunes.getExplicitNullable()) {
+                element.addContent(generateSimpleElement("explicit", "yes"));
+            } else {
+                element.addContent(generateSimpleElement("explicit", "no"));
+            }
         }
 
         if (itunes.getImage() != null) {

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
@@ -18,6 +18,7 @@ package com.rometools.modules.itunes.io;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.StringTokenizer;
@@ -41,6 +42,9 @@ import com.rometools.rome.io.WireFeedParser;
 public class ITunesParser implements ModuleParser {
 
     private static final Logger LOG = LoggerFactory.getLogger(ITunesParser.class);
+
+    private static final List<String> EXPLICIT_TRUE = Arrays.asList("yes", "explicit", "true");
+    private static final List<String> EXPLICIT_FALSE = Arrays.asList("clean", "no", "false");
 
     Namespace ns = Namespace.getNamespace(AbstractITunesObject.URI);
 
@@ -192,8 +196,16 @@ public class ITunesParser implements ModuleParser {
 
             final Element explicit = element.getChild("explicit", ns);
 
-            if (explicit != null && explicit.getValue() != null && explicit.getValue().trim().equalsIgnoreCase("yes")) {
-                module.setExplicit(true);
+            if (explicit != null && explicit.getValue() != null) {
+                String explicitValue = explicit.getValue().trim();
+
+                if (EXPLICIT_TRUE.contains(explicitValue)) {
+                    module.setExplicit(true);
+                }
+
+                if (EXPLICIT_FALSE.contains(explicitValue)) {
+                    module.setExplicit(false);
+                }
             }
 
             final Element keywords = element.getChild("keywords", ns);

--- a/rome-modules/src/test/java/com/rometools/modules/itunes/ITunesParserTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/itunes/ITunesParserTest.java
@@ -136,6 +136,16 @@ public class ITunesParserTest extends AbstractTestCase {
         assertEquals(true, entryInfo.getClosedCaptioned());
         assertEquals(Integer.valueOf(2), entryInfo.getOrder());
         assertEquals("http://example.org/image.png", entryInfo.getImage().toString());
+        assertFalse(entryInfo.getExplicit());
+
+        SyndEntry entry1 = syndfeed.getEntries().get(1);
+        EntryInformationImpl entryInfo1 = (EntryInformationImpl) entry1.getModule(AbstractITunesObject.URI);
+        assertTrue(entryInfo1.getExplicit());
+
+        SyndEntry entry2 = syndfeed.getEntries().get(2);
+        EntryInformationImpl entryInfo2 = (EntryInformationImpl) entry2.getModule(AbstractITunesObject.URI);
+        assertFalse(entryInfo2.getExplicit());
+        assertNull(entryInfo2.getExplicitNullable());
     }
 
     public void testDuration() throws Exception {

--- a/rome-modules/src/test/resources/xml/leshow.xml
+++ b/rome-modules/src/test/resources/xml/leshow.xml
@@ -107,7 +107,7 @@
 
 
 
-    <itunes:explicit>no</itunes:explicit>
+    <itunes:explicit>yes</itunes:explicit>
 	
 	    <itunes:duration>44:00</itunes:duration>
 	
@@ -148,8 +148,7 @@
 
 
 
-    <itunes:explicit>no</itunes:explicit>
-	
+
 	    <itunes:duration>48:33</itunes:duration>
 	
     <itunes:keywords></itunes:keywords>  
@@ -186,8 +185,7 @@
 
 
 
-    <itunes:explicit>no</itunes:explicit>
-	
+
 	    <itunes:duration>45:56</itunes:duration>
 	
     <itunes:keywords></itunes:keywords>  


### PR DESCRIPTION
From itunes docs:
 - "If you specify yes, explicit, or true, indicating the presence of
explicit content, Apple Podcasts displays an Explicit parental advisory
graphic for your podcast"
 - "If you specify clean, no, or false, indicating that your podcast
doesn’t contain explicit language or adult content, Apple Podcasts
displays a Clean parental advisory graphic for your podcast"

Also made it possible to distinguish non-explicit content from content
with unspecified explicitness. Added separate getter to keep backward
compatibility.

Fixes #244