### PR TITLE
Use correct value for itunes:block tag

### DIFF
--- a/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesGenerator.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesGenerator.java
@@ -128,7 +128,7 @@ public class ITunesGenerator implements ModuleGenerator {
         }
 
         if (itunes.getBlock()) {
-            element.addContent(generateSimpleElement("block", ""));
+            element.addContent(generateSimpleElement("block", "Yes"));
         }
 
         if (itunes.getExplicitNullable() != null) {

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
@@ -196,7 +196,10 @@ public class ITunesParser implements ModuleParser {
 
             final Element block = element.getChild("block", ns);
 
-            if (block != null) {
+            // Ignore case of the value, assuming that any kind of "yes" clearly shows the intent.
+            if (block != null
+                    && block.getValue() != null
+                    && block.getValue().trim().equalsIgnoreCase("Yes")) {
                 module.setBlock(true);
             }
 

--- a/rome-modules/src/test/java/com/rometools/modules/itunes/ITunesParserTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/itunes/ITunesParserTest.java
@@ -83,6 +83,7 @@ public class ITunesParserTest extends AbstractTestCase {
         final Module module = syndfeed.getModule(AbstractITunesObject.URI);
         final FeedInformationImpl feedInfo = (FeedInformationImpl) module;
 
+        assertTrue(feedInfo.getBlock());
         assertEquals("owner", "Harry Shearer", feedInfo.getOwnerName());
         assertEquals("email", "", feedInfo.getOwnerEmailAddress());
         assertEquals("image", "http://a1.phobos.apple.com/Music/y2005/m06/d26/h21/mcdrrifv.jpg", feedInfo.getImage().toExternalForm());

--- a/rome-modules/src/test/resources/itunes/leshow.xml
+++ b/rome-modules/src/test/resources/itunes/leshow.xml
@@ -10,6 +10,7 @@
         <itunes:type>serial</itunes:type>
         <itunes:complete>yes</itunes:complete>
         <itunes:new-feed-url>http://example.org</itunes:new-feed-url>
+        <itunes:block>Yes</itunes:block>
         <language>en</language>
 
         <copyright>KCRW 2005</copyright>


### PR DESCRIPTION
From itunes spec: "Specifying the itunes:block tag with a Yes value at
the channel level (podcast), prevents the entire podcast from appearing
in Apple Podcasts."

Fixes #393