### PR TITLE
Podlove Simple Chapter support

### DIFF
--- a/rome-modules/src/main/java/com/rometools/modules/psc/io/PodloveSimpleChapterAttribute.java
+++ b/rome-modules/src/main/java/com/rometools/modules/psc/io/PodloveSimpleChapterAttribute.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Maximilian Irro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.rometools.modules.psc.io;
+
+/**
+ * Constant definitions for XML attribute names.
+ */
+public interface PodloveSimpleChapterAttribute {
+
+    // namespace prefix
+
+    /** "psc". */
+    String PREFIX = "psc";
+
+
+    // name of the list of chapters
+
+    /** "chapters". */
+    String CHAPTERS = "chapters";
+
+    /** "version". */
+    String VERSION = "version";
+
+
+    // name of a chapter entry
+
+    /** "chapter". */
+    String CHAPTER = "chapter";
+
+
+    // attributes of single chapter entries
+
+    /** "start". */
+    String START = "start";
+
+    /** "title". */
+    String TITLE = "title";
+
+    /** "href". */
+    String HREF = "href";
+
+    /** "image". */
+    String IMAGE = "image";
+}

--- a/rome-modules/src/main/java/com/rometools/modules/psc/io/PodloveSimpleChapterGenerator.java
+++ b/rome-modules/src/main/java/com/rometools/modules/psc/io/PodloveSimpleChapterGenerator.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 Maximilian Irro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.rometools.modules.psc.io;
+
+import com.rometools.modules.psc.modules.PodloveSimpleChapterModule;
+import com.rometools.modules.psc.types.SimpleChapter;
+import com.rometools.rome.feed.module.Module;
+import com.rometools.rome.io.ModuleGenerator;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The ModuleGenerator implementation for the Podlove Simple Chapter plug in.
+ */
+public class PodloveSimpleChapterGenerator implements ModuleGenerator {
+
+    private static final Namespace NS = Namespace.getNamespace(PodloveSimpleChapterAttribute.PREFIX, PodloveSimpleChapterModule.URI);
+    private static final Set<Namespace> NAMESPACES;
+
+    static {
+        final Set<Namespace> nss = new HashSet<Namespace>();
+        nss.add(NS);
+        NAMESPACES = Collections.unmodifiableSet(nss);
+    }
+
+    @Override
+    public final String getNamespaceUri() {
+        return PodloveSimpleChapterModule.URI;
+    }
+
+    @Override
+    public final Set<Namespace> getNamespaces() {
+        return NAMESPACES;
+    }
+
+    @Override
+    public void generate(Module module, Element element) {
+        if (module instanceof PodloveSimpleChapterModule) {
+            final PodloveSimpleChapterModule m = (PodloveSimpleChapterModule) module;
+            generateChapters(m.getChapters(), element);
+        }
+    }
+
+    private void generateChapters(final List<SimpleChapter> chapters, final Element parent) {
+        final Element cs = new Element(PodloveSimpleChapterAttribute.CHAPTERS, NS);
+
+        cs.setAttribute(PodloveSimpleChapterAttribute.VERSION, PodloveSimpleChapterModule.VERSION);
+
+        for (SimpleChapter c : chapters) {
+            cs.addContent(generateChapter(c));
+        }
+
+        parent.addContent(cs);
+    }
+
+    private Element generateChapter(final SimpleChapter c) {
+        final Element e = new Element(PodloveSimpleChapterAttribute.CHAPTER, NS);
+
+        addNotNullAttribute(e, PodloveSimpleChapterAttribute.START, c.getStart());
+        addNotNullAttribute(e, PodloveSimpleChapterAttribute.TITLE, c.getTitle());
+        addNotNullAttribute(e, PodloveSimpleChapterAttribute.HREF, c.getHref());
+        addNotNullAttribute(e, PodloveSimpleChapterAttribute.IMAGE, c.getImage());
+
+        return e;
+    }
+
+    private void addNotNullAttribute(final Element target, final String name, final Object value) {
+        if (target == null || value == null) {
+            return;
+        } else {
+            target.setAttribute(name, value.toString());
+        }
+    }
+}

--- a/rome-modules/src/main/java/com/rometools/modules/psc/io/PodloveSimpleChapterParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/psc/io/PodloveSimpleChapterParser.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 Maximilian Irro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.rometools.modules.psc.io;
+
+import com.rometools.modules.psc.types.SimpleChapter;
+import com.rometools.modules.psc.modules.PodloveSimpleChapterModule;
+import com.rometools.modules.psc.modules.PodloveSimpleChapterModuleImpl;
+import com.rometools.rome.feed.module.Module;
+import com.rometools.rome.io.ModuleParser;
+import org.jdom2.Attribute;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * The ModuleParser implementation for the Podlove Simple Chapter plug in.
+ */
+public class PodloveSimpleChapterParser implements ModuleParser {
+
+    private static final Namespace NS = Namespace.getNamespace(PodloveSimpleChapterModule.URI);
+
+    @Override
+    public String getNamespaceUri() {
+        return PodloveSimpleChapterModule.URI;
+    }
+
+    @Override
+    public Module parse(final Element element, final Locale locale) {
+        final Element chaptersElement = element.getChild(PodloveSimpleChapterAttribute.CHAPTERS, NS);
+        if (chaptersElement != null) {
+            final PodloveSimpleChapterModuleImpl m = new PodloveSimpleChapterModuleImpl();
+            final List<Element> es = chaptersElement.getChildren(PodloveSimpleChapterAttribute.CHAPTER, NS);
+            if (!es.isEmpty()) {
+                final List<SimpleChapter> result = new LinkedList<SimpleChapter>();
+                for (Element e : es) {
+                    final SimpleChapter c = parseChapter(e);
+                    result.add(c);
+                }
+                m.setChapters(result);
+                return m;
+            }
+        }
+
+        return null;
+    }
+
+    private SimpleChapter parseChapter(final Element eChapter) {
+        final SimpleChapter chapter = new SimpleChapter();
+
+        final String start = getAttributeValue(eChapter, PodloveSimpleChapterAttribute.START);
+        if (start != null) {
+            chapter.setStart(start);
+        }
+
+        final String title = getAttributeValue(eChapter, PodloveSimpleChapterAttribute.TITLE);
+        if (title != null) {
+            chapter.setTitle(title);
+        }
+
+        final String href = getAttributeValue(eChapter, PodloveSimpleChapterAttribute.HREF);
+        if (href != null) {
+            chapter.setHref(href);
+        }
+
+        final String image = getAttributeValue(eChapter, PodloveSimpleChapterAttribute.IMAGE);
+        if (image != null) {
+            chapter.setImage(image);
+        }
+
+        return chapter;
+    }
+
+    protected String getAttributeValue(final Element e, final String attributeName) {
+        Attribute attr = e.getAttribute(attributeName);
+        if (attr == null) {
+            attr = e.getAttribute(attributeName, NS);
+        }
+        if (attr != null) {
+            return attr.getValue();
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/rome-modules/src/main/java/com/rometools/modules/psc/io/package.html
+++ b/rome-modules/src/main/java/com/rometools/modules/psc/io/package.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+
+<html>
+  <head>
+    <title></title>
+  </head>
+  <body>
+   This package contains the parser and generator for ROME.
+  </body>
+</html>

--- a/rome-modules/src/main/java/com/rometools/modules/psc/modules/PodloveSimpleChapterModule.java
+++ b/rome-modules/src/main/java/com/rometools/modules/psc/modules/PodloveSimpleChapterModule.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Maximilian Irro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.rometools.modules.psc.modules;
+
+import com.rometools.modules.psc.types.SimpleChapter;
+import com.rometools.rome.feed.CopyFrom;
+import com.rometools.rome.feed.module.Module;
+
+import java.util.List;
+
+/**
+ * An interface describing the item level data for Podlove Simple Chapters.
+ */
+public interface PodloveSimpleChapterModule extends Module, CopyFrom {
+
+    /** "http://podlove.org/simple-chapters". */
+    String URI = "http://podlove.org/simple-chapters";
+
+    /** "1.2". */
+    String VERSION = "1.2";
+
+    /**
+     * Returns the SimpleChapters of an item element.
+     *
+     * @return List of SimpleChapters of an item element
+     */
+    List<SimpleChapter> getChapters();
+
+    /**
+     * Sets the SimpleChapters of an item element.
+     *
+     * @param chapters List of SimpleChapters of an item element
+     */
+    void setChapters(List<SimpleChapter> chapters);
+
+}

--- a/rome-modules/src/main/java/com/rometools/modules/psc/modules/PodloveSimpleChapterModuleImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/psc/modules/PodloveSimpleChapterModuleImpl.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 Maximilian Irro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.rometools.modules.psc.modules;
+
+import com.rometools.modules.psc.types.SimpleChapter;
+import com.rometools.rome.feed.CopyFrom;
+import com.rometools.rome.feed.impl.EqualsBean;
+import com.rometools.rome.feed.impl.ToStringBean;
+import com.rometools.rome.feed.module.ModuleImpl;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * A Module implementation for item level Simple Chapter information.
+ */
+public class PodloveSimpleChapterModuleImpl
+        extends ModuleImpl
+        implements PodloveSimpleChapterModule, Cloneable, Serializable {
+
+    private List<SimpleChapter> chapters;
+
+    public PodloveSimpleChapterModuleImpl() {
+        super(PodloveSimpleChapterModule.class, PodloveSimpleChapterModule.URI);
+    }
+
+    @Override
+    public List<SimpleChapter> getChapters() {
+        return (chapters==null) ? (chapters = new LinkedList<SimpleChapter>()) : chapters;
+    }
+
+    @Override
+    public void setChapters(final List<SimpleChapter> chapters) {
+        this.chapters = chapters;
+    }
+
+    @Override
+    public Class<? extends CopyFrom> getInterface() {
+        return PodloveSimpleChapterModule.class;
+    }
+
+    @Override
+    public void copyFrom(final CopyFrom obj) {
+        final PodloveSimpleChapterModule mod = (PodloveSimpleChapterModule) obj;
+        final List<SimpleChapter> chapters = new LinkedList<SimpleChapter>();
+        for(SimpleChapter c1 : mod.getChapters()) {
+            final SimpleChapter c2 = new SimpleChapter();
+            c2.copyFrom(c1);
+            chapters.add(c2);
+        }
+        setChapters(chapters);
+    }
+
+    @Override
+    public String getUri() {
+        return PodloveSimpleChapterModule.URI;
+    }
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        final PodloveSimpleChapterModuleImpl mod = new PodloveSimpleChapterModuleImpl();
+        final List<SimpleChapter> result = new LinkedList<SimpleChapter>();
+        for (SimpleChapter c1 : this.chapters){
+            SimpleChapter c2 = new SimpleChapter();
+            c2.copyFrom(c1);
+            result.add(c2);
+        }
+        result.subList(0, result.size()); // not sure why I need to do this
+        mod.setChapters(result);
+        return mod;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        final EqualsBean eBean = new EqualsBean(PodloveSimpleChapterModuleImpl.class, this);
+        return eBean.beanEquals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        final EqualsBean equals = new EqualsBean(PodloveSimpleChapterModuleImpl.class, this);
+        return equals.beanHashCode();
+    }
+
+    @Override
+    public String toString() {
+        final ToStringBean tsBean = new ToStringBean(PodloveSimpleChapterModuleImpl.class, this);
+        return tsBean.toString();
+    }
+}

--- a/rome-modules/src/main/java/com/rometools/modules/psc/modules/package.html
+++ b/rome-modules/src/main/java/com/rometools/modules/psc/modules/package.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+
+<html>
+  <head>
+    <title></title>
+  </head>
+  <body>
+   This package contains the module interface and implementation for ROME.
+  </body>
+</html>

--- a/rome-modules/src/main/java/com/rometools/modules/psc/package.html
+++ b/rome-modules/src/main/java/com/rometools/modules/psc/package.html
@@ -1,0 +1,29 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+
+<html>
+<head>
+    <title></title>
+</head>
+<body>
+
+This is a ROME plug in that implements the <a href="https://podlove.org/simple-chapters/">Podlove Simple Chapters</a> RSS extension.
+
+<h2>Sample Usage:</h2>
+<pre>
+
+    final SyndFeedInput input = new SyndFeedInput();
+    final SyndFeed syndfeed = input.build(new XmlReader(feed.toURL()));
+
+    for (SyndEntry syndEntry : syndfeed.getEntries()) {
+        final Module module = syndEntry.getModule(PodloveSimpleChapterModule.URI);
+        final PodloveSimpleChapterModule chapterModule = ((PodloveSimpleChapterModule) module);
+
+        final List<SimpleChapter> chapters = chapterModule.getChapters();
+        for (SimpleChapter c : chapters) {
+            System.out.println( c.toString );
+        }
+    }
+
+</pre>
+</body>
+</html>

--- a/rome-modules/src/main/java/com/rometools/modules/psc/types/SimpleChapter.java
+++ b/rome-modules/src/main/java/com/rometools/modules/psc/types/SimpleChapter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Maximilian Irro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.rometools.modules.psc.types;
+
+import com.rometools.rome.feed.CopyFrom;
+
+/**
+ * Simple Chapter entry information.
+ */
+public class SimpleChapter implements CopyFrom {
+
+    private String start;
+    private String title;
+    private String href;
+    private String image;
+
+    public String getStart() {
+        return start;
+    }
+
+    public void setStart(String start) {
+        this.start = start;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getHref() {
+        return href;
+    }
+
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    @Override
+    public Class<? extends CopyFrom> getInterface() {
+        return SimpleChapter.class;
+    }
+
+    @Override
+    public void copyFrom(CopyFrom obj) {
+        final SimpleChapter item = (SimpleChapter) obj;
+        setStart(item.getStart());
+        setTitle(item.getTitle());
+        setHref(item.getHref());
+        setImage(item.getImage());
+    }
+
+    @Override
+    public String toString() {
+        return "SimpleChapter{" +
+            "start='" + start + '\'' +
+            ", title='" + title + '\'' +
+            ", href='" + href + '\'' +
+            ", image='" + image + '\'' +
+            '}';
+    }
+}

--- a/rome-modules/src/main/resources/rome.properties
+++ b/rome-modules/src/main/resources/rome.properties
@@ -48,13 +48,15 @@ rss_2.0.item.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS2 \
     com.rometools.modules.itunes.io.ITunesParserOldNamespace \
     com.rometools.modules.mediarss.io.AlternateMediaModuleParser \
     com.rometools.modules.sle.io.ItemParser \
-    com.rometools.modules.yahooweather.io.WeatherModuleParser
+    com.rometools.modules.yahooweather.io.WeatherModuleParser \
+    com.rometools.modules.psc.io.PodloveSimpleChapterParser
 
 rss_1.0.item.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS1 \
     com.rometools.modules.base.io.GoogleBaseParser \
     com.rometools.modules.base.io.CustomTagParser \
     com.rometools.modules.content.io.ContentModuleParser \
-    com.rometools.modules.slash.io.SlashModuleParser
+    com.rometools.modules.slash.io.SlashModuleParser \
+    com.rometools.modules.psc.io.PodloveSimpleChapterParser
 
 atom_0.3.item.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS2 \
     com.rometools.modules.base.io.GoogleBaseParser \
@@ -65,7 +67,8 @@ atom_0.3.item.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS2 
     com.rometools.modules.georss.W3CGeoParser \
     com.rometools.modules.photocast.io.Parser \
     com.rometools.modules.mediarss.io.MediaModuleParser \
-    com.rometools.modules.mediarss.io.AlternateMediaModuleParser
+    com.rometools.modules.mediarss.io.AlternateMediaModuleParser \
+    com.rometools.modules.psc.io.PodloveSimpleChapterParser
 
 atom_1.0.item.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS2 \
     com.rometools.modules.base.io.GoogleBaseParser \
@@ -77,7 +80,8 @@ atom_1.0.item.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS2 
     com.rometools.modules.photocast.io.Parser \
     com.rometools.modules.mediarss.io.MediaModuleParser \
     com.rometools.modules.mediarss.io.AlternateMediaModuleParser \
-    com.rometools.modules.thr.io.ThreadingModuleParser
+    com.rometools.modules.thr.io.ThreadingModuleParser \
+    com.rometools.modules.psc.io.PodloveSimpleChapterParser
 
 rss_2.0.feed.ModuleGenerator.classes=com.rometools.modules.cc.io.CCModuleGenerator \
     com.rometools.modules.content.io.ContentModuleGenerator \
@@ -123,7 +127,8 @@ rss_2.0.item.ModuleGenerator.classes=com.rometools.modules.cc.io.CCModuleGenerat
 
 rss_1.0.item.ModuleGenerator.classes=com.rometools.modules.base.io.GoogleBaseGenerator \
     com.rometools.modules.content.io.ContentModuleGenerator \
-    com.rometools.modules.slash.io.SlashModuleGenerator
+    com.rometools.modules.slash.io.SlashModuleGenerator \
+    com.rometools.modules.psc.io.PodloveSimpleChapterGenerator
 
 atom_0.3.item.ModuleGenerator.classes=com.rometools.modules.cc.io.CCModuleGenerator \
     com.rometools.modules.base.io.GoogleBaseGenerator \
@@ -133,7 +138,8 @@ atom_0.3.item.ModuleGenerator.classes=com.rometools.modules.cc.io.CCModuleGenera
     com.rometools.modules.georss.SimpleGenerator \
     com.rometools.modules.georss.W3CGeoGenerator \
     com.rometools.modules.photocast.io.Generator \
-    com.rometools.modules.mediarss.io.MediaModuleGenerator
+    com.rometools.modules.mediarss.io.MediaModuleGenerator \
+    com.rometools.modules.psc.io.PodloveSimpleChapterGenerator
 
 atom_1.0.item.ModuleGenerator.classes=com.rometools.modules.cc.io.CCModuleGenerator \
     com.rometools.modules.base.io.CustomTagGenerator \
@@ -143,7 +149,8 @@ atom_1.0.item.ModuleGenerator.classes=com.rometools.modules.cc.io.CCModuleGenera
     com.rometools.modules.georss.W3CGeoGenerator \
     com.rometools.modules.photocast.io.Generator \
     com.rometools.modules.mediarss.io.MediaModuleGenerator \
-    com.rometools.modules.thr.io.ThreadingModuleGenerator
+    com.rometools.modules.thr.io.ThreadingModuleGenerator \
+    com.rometools.modules.psc.io.PodloveSimpleChapterGenerator
 
 rss_2.0wNS.feed.ModuleParser.classes=com.rometools.modules.mediarss.io.MediaModuleParser
 rss_2.0wNS.item.ModuleParser.classes=com.rometools.modules.mediarss.io.MediaModuleParser

--- a/rome-modules/src/test/java/com/rometools/modules/psc/PodloveSimpleChapterGeneratorTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/psc/PodloveSimpleChapterGeneratorTest.java
@@ -1,0 +1,62 @@
+package com.rometools.modules.psc;
+
+import com.rometools.modules.AbstractTestCase;
+import com.rometools.modules.psc.io.PodloveSimpleChapterGenerator;
+import com.rometools.modules.psc.modules.PodloveSimpleChapterModule;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.SyndFeedInput;
+import com.rometools.rome.io.SyndFeedOutput;
+import com.rometools.rome.io.XmlReader;
+import junit.framework.TestSuite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.StringWriter;
+
+public class PodloveSimpleChapterGeneratorTest extends AbstractTestCase {
+
+    private static final Logger log = LoggerFactory.getLogger(PodloveSimpleChapterGeneratorTest.class);
+
+    public PodloveSimpleChapterGeneratorTest(final String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected void setUp() {
+    }
+
+    @Override
+    protected void tearDown() {
+    }
+
+    public static junit.framework.Test suite() {
+        return new TestSuite(PodloveSimpleChapterGeneratorTest.class);
+    }
+
+    public void testGenerate() throws Exception {
+
+        log.debug("testGenerate");
+
+        final SyndFeedInput input = new SyndFeedInput();
+        final SyndFeed feed = input.build(new XmlReader(new File(getTestFile("psc/test1.xml")).toURI().toURL()));
+        final SyndEntry entry = feed.getEntries().get(0);
+        entry.getModule(PodloveSimpleChapterModule.URI);
+        final SyndFeedOutput output = new SyndFeedOutput();
+        final StringWriter writer = new StringWriter();
+        output.output(feed, writer);
+
+        log.debug("{}", writer);
+
+    }
+
+    public void testGetNamespaces() {
+        // TODO add test code
+    }
+
+    public void testGetNamespaceUri() {
+        assertEquals("Namespace", PodloveSimpleChapterModule.URI, new PodloveSimpleChapterGenerator().getNamespaceUri());
+    }
+
+}

--- a/rome-modules/src/test/java/com/rometools/modules/psc/PodloveSimpleChapterParserTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/psc/PodloveSimpleChapterParserTest.java
@@ -1,0 +1,59 @@
+package com.rometools.modules.psc;
+
+import com.rometools.modules.AbstractTestCase;
+import com.rometools.modules.psc.io.PodloveSimpleChapterParser;
+import com.rometools.modules.psc.modules.PodloveSimpleChapterModule;
+import com.rometools.modules.psc.types.SimpleChapter;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.SyndFeedInput;
+import com.rometools.rome.io.XmlReader;
+import junit.framework.TestSuite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+public class PodloveSimpleChapterParserTest extends AbstractTestCase {
+
+    private static final Logger log = LoggerFactory.getLogger(PodloveSimpleChapterParserTest.class);
+
+    public PodloveSimpleChapterParserTest(final String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected void setUp() {
+    }
+
+    @Override
+    protected void tearDown() {
+    }
+
+    public static junit.framework.Test suite() {
+        return new TestSuite(PodloveSimpleChapterParserTest.class);
+    }
+
+    public void testParse() throws Exception {
+
+        log.debug("testParse");
+
+        final SyndFeedInput input = new SyndFeedInput();
+        final SyndFeed feed = input.build(new XmlReader(new File(getTestFile("psc/test1.xml")).toURI().toURL()));
+        final SyndEntry entry = feed.getEntries().get(0);
+        final PodloveSimpleChapterModule module = (PodloveSimpleChapterModule) entry.getModule(PodloveSimpleChapterModule.URI);
+
+        for (SimpleChapter c : module.getChapters()) {
+            assertEquals("00:00:00.000", c.getStart());
+            assertEquals("Lorem Ipsum", c.getTitle());
+            assertEquals("http://example.org", c.getHref());
+            assertEquals("http://example.org/cover", c.getImage());
+        }
+
+    }
+
+    public void testGetNamespaceUri() {
+        assertEquals("Namespace", PodloveSimpleChapterModule.URI, new PodloveSimpleChapterParser().getNamespaceUri());
+    }
+
+}

--- a/rome-modules/src/test/resources/psc/test1.xml
+++ b/rome-modules/src/test/resources/psc/test1.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" media="screen" href="/~files/feed-premium.xsl"?>
+
+<rss xmlns:psc="http://podlove.org/simple-chapters" version="2.0">
+    <channel>
+        <title>Lorem Ipsum</title>
+        <link>http://example.org</link>
+        <description>Lorem Ipsum</description>
+        <item>
+            <title>Lorem Ipsum</title>
+            <link>http://example.org/episode1</link>
+            <description><![CDATA[Lorem Ipsum]]></description>
+            <psc:chapters xmlns:psc="http://podlove.org/simple-chapters" version="1.2">
+                <psc:chapter start="00:00:00.000" title="Lorem Ipsum" href="http://example.org" image="http://example.org/cover"/>
+                <psc:chapter start="00:00:00.000" title="Lorem Ipsum" href="http://example.org" image="http://example.org/cover"/>
+                <psc:chapter start="00:00:00.000" title="Lorem Ipsum" href="http://example.org" image="http://example.org/cover"/>
+            </psc:chapters>
+        </item>
+    </channel>
+</rss>


### PR DESCRIPTION
The Podlove Project's Simple Chapter format ([podlove.org/simple-chapters/](https://podlove.org/simple-chapters/)) adds chapter mark informations about the enclosures of feed items (relevant to the feeds of podcasts). This module provides a respective parser and generator.

I am using this code already in my own project. I would appreciate if you add this module for the next ROME version.