### PR TITLE
Supporting SyndCategory label

### DIFF
--- a/rome/src/main/java/com/rometools/rome/feed/module/DCSubject.java
+++ b/rome/src/main/java/com/rometools/rome/feed/module/DCSubject.java
@@ -44,6 +44,23 @@ public interface DCSubject extends Cloneable, CopyFrom {
     void setTaxonomyUri(String taxonomyUri);
 
     /**
+     *
+     * Returns the category label, <b>null</b> if none.
+     * <p>
+     * @return label, <b>null</b> if none
+     * </p>
+     */
+    String getLabel();
+
+    /**
+     * Sets the subject label
+     * <p>
+     * @param label the category label to set, <b>null</b> if none.
+     * </p>
+     */
+    void setLabel(String label);
+
+    /**
      * Returns the DublinCore subject value.
      * <p>
      *
@@ -70,5 +87,6 @@ public interface DCSubject extends Cloneable, CopyFrom {
      *
      */
     public Object clone() throws CloneNotSupportedException;
+
 
 }

--- a/rome/src/main/java/com/rometools/rome/feed/module/DCSubject.java
+++ b/rome/src/main/java/com/rometools/rome/feed/module/DCSubject.java
@@ -44,23 +44,6 @@ public interface DCSubject extends Cloneable, CopyFrom {
     void setTaxonomyUri(String taxonomyUri);
 
     /**
-     *
-     * Returns the category label, <b>null</b> if none.
-     * <p>
-     * @return label, <b>null</b> if none
-     * </p>
-     */
-    String getLabel();
-
-    /**
-     * Sets the subject label
-     * <p>
-     * @param label the category label to set, <b>null</b> if none.
-     * </p>
-     */
-    void setLabel(String label);
-
-    /**
      * Returns the DublinCore subject value.
      * <p>
      *

--- a/rome/src/main/java/com/rometools/rome/feed/module/DCSubjectImpl.java
+++ b/rome/src/main/java/com/rometools/rome/feed/module/DCSubjectImpl.java
@@ -136,27 +136,6 @@ public class DCSubjectImpl implements Cloneable, Serializable, DCSubject {
     }
 
     /**
-     *
-     * Returns the category label, <b>null</b> if none.
-     * <p>
-     * @return label, <b>null</b> if none
-     * </p>
-     */
-    @Override
-    public String getLabel() {return label;}
-
-    /**
-     * Sets the subject label
-     * <p>
-     * @param label the category label to set, <b>null</b> if none.
-     * </p>
-     */
-    @Override
-    public void setLabel(final String label)  {
-        this.label = label;
-    }
-
-    /**
      * Returns the DublinCore subject value.
      * <p>
      *

--- a/rome/src/main/java/com/rometools/rome/feed/module/DCSubjectImpl.java
+++ b/rome/src/main/java/com/rometools/rome/feed/module/DCSubjectImpl.java
@@ -40,11 +40,13 @@ public class DCSubjectImpl implements Cloneable, Serializable, DCSubject {
 
     private String taxonomyUri;
     private String value;
+    private String label;
 
     static {
         final Map<String, Class<?>> basePropInterfaceMap = new HashMap<String, Class<?>>();
         basePropInterfaceMap.put("taxonomyUri", String.class);
         basePropInterfaceMap.put("value", String.class);
+        basePropInterfaceMap.put("label",String.class);
 
         final Map<Class<? extends CopyFrom>, Class<?>> basePropClassImplMap = Collections.<Class<? extends CopyFrom>, Class<?>> emptyMap();
 
@@ -131,6 +133,27 @@ public class DCSubjectImpl implements Cloneable, Serializable, DCSubject {
     @Override
     public void setTaxonomyUri(final String taxonomyUri) {
         this.taxonomyUri = taxonomyUri;
+    }
+
+    /**
+     *
+     * Returns the category label, <b>null</b> if none.
+     * <p>
+     * @return label, <b>null</b> if none
+     * </p>
+     */
+    @Override
+    public String getLabel() {return label;}
+
+    /**
+     * Sets the subject label
+     * <p>
+     * @param label the category label to set, <b>null</b> if none.
+     * </p>
+     */
+    @Override
+    public void setLabel(final String label)  {
+        this.label = label;
     }
 
     /**

--- a/rome/src/main/java/com/rometools/rome/feed/synd/SyndCategory.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/SyndCategory.java
@@ -60,6 +60,19 @@ public interface SyndCategory extends Cloneable, CopyFrom {
     void setTaxonomyUri(String taxonomyUri);
 
     /**
+     * Sets the category Label
+     * <p>
+     * @param label the catagory label to set, <b>null</b> if none
+     * </p>
+     */
+    void setLabel(String label);
+
+    /**
+     * Returns the category label, <b>null</b> if none
+     */
+    String getLabel();
+
+    /**
      * Creates a deep clone of the object.
      * <p>
      *

--- a/rome/src/main/java/com/rometools/rome/feed/synd/SyndCategoryImpl.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/SyndCategoryImpl.java
@@ -45,6 +45,7 @@ public class SyndCategoryImpl implements Serializable, SyndCategory {
         final Map<String, Class<?>> basePropInterfaceMap = new HashMap<String, Class<?>>();
         basePropInterfaceMap.put("name", String.class);
         basePropInterfaceMap.put("taxonomyUri", String.class);
+        basePropInterfaceMap.put("label", String.class);
         final Map<Class<? extends CopyFrom>, Class<?>> basePropClassImplMap = Collections.emptyMap();
         COPY_FROM_HELPER = new CopyFromHelper(SyndCategory.class, basePropInterfaceMap, basePropClassImplMap);
     }

--- a/rome/src/main/java/com/rometools/rome/feed/synd/SyndCategoryImpl.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/SyndCategoryImpl.java
@@ -40,6 +40,7 @@ public class SyndCategoryImpl implements Serializable, SyndCategory {
     private static final CopyFromHelper COPY_FROM_HELPER;
 
     private final DCSubject subject;
+    private String label;
 
     static {
         final Map<String, Class<?>> basePropInterfaceMap = new HashMap<String, Class<?>>();
@@ -164,11 +165,11 @@ public class SyndCategoryImpl implements Serializable, SyndCategory {
      */
     @Override
     public void setLabel(final String label) {
-        subject.setLabel(label);
+        this.label = label;
     }
 
     @Override
-    public String getLabel() { return subject.getLabel(); }
+    public String getLabel() { return label; }
 
     /**
      * Returns the category taxonomy URI.

--- a/rome/src/main/java/com/rometools/rome/feed/synd/SyndCategoryImpl.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/SyndCategoryImpl.java
@@ -155,6 +155,14 @@ public class SyndCategoryImpl implements Serializable, SyndCategory {
         subject.setValue(name);
     }
 
+    @Override
+    public void setLabel(final String label) {
+        subject.setLabel(label);
+    }
+
+    @Override
+    public String getLabel() { return subject.getLabel(); }
+
     /**
      * Returns the category taxonomy URI.
      * <p>

--- a/rome/src/main/java/com/rometools/rome/feed/synd/SyndCategoryImpl.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/SyndCategoryImpl.java
@@ -156,6 +156,12 @@ public class SyndCategoryImpl implements Serializable, SyndCategory {
         subject.setValue(name);
     }
 
+    /**
+     * Sets the category Label.
+     * <p>
+     * @param label the category label to set, <b>null</b> if none
+     *
+     */
     @Override
     public void setLabel(final String label) {
         subject.setLabel(label);

--- a/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom10.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom10.java
@@ -556,7 +556,7 @@ public class ConverterForAtom10 implements Converter {
             for (final SyndCategory sCat : sCats) {
                 final Category aCat = new Category();
                 aCat.setTerm(sCat.getName());
-                // TODO: aCat.setLabel(sCat.getLabel());
+                aCat.setLabel(sCat.getLabel());
                 aCat.setScheme(sCat.getTaxonomyUri());
                 aCats.add(aCat);
             }

--- a/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom10.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom10.java
@@ -241,8 +241,7 @@ public class ConverterForAtom10 implements Converter {
                 final SyndCategory syndCategory = new SyndCategoryImpl();
                 syndCategory.setName(category.getTerm());
                 syndCategory.setTaxonomyUri(category.getSchemeResolved());
-                // TODO: categories MAY have labels
-                // syndCategory.setLabel(c.getLabel());
+                syndCategory.setLabel(category.getLabel());
                 syndCategories.add(syndCategory);
             }
             syndEntry.setCategories(syndCategories);


### PR DESCRIPTION
With this patch, categories in Atom Feeds now supports labels. 
Supporting labels in categories was marked as TODO in the previous source code.

Example:
SyndCategory crsCategory = new SyndCategoryImpl();
crsCategory.setName("EPSG:4258");
crsCategory.setTaxonomyUri("http://www.opengis.net/def/crs/");
crsCategory.setLabel("EPSG/0/4258");

results in:
&LT;category term="EPSG:4258" scheme="http://www.opengis.net/def/crs/" label="EPSG/0/4258"/>

