### PR TITLE
Fixes #411: an additional masks added to DataParser

### DIFF
--- a/rome/src/main/java/com/rometools/rome/io/impl/DateParser.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/DateParser.java
@@ -47,7 +47,7 @@ public class DateParser {
     // parse a valid date out of a substring of the full string given the mask so we have to check
     // the most complete format first, then it fails with exception
     private static final String[] W3CDATETIME_MASKS = { "yyyy-MM-dd'T'HH:mm:ss.SSSz", "yyyy-MM-dd't'HH:mm:ss.SSSz", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-            "yyyy-MM-dd't'HH:mm:ss.SSS'z'", "yyyy-MM-dd'T'HH:mm:ssz", "yyyy-MM-dd't'HH:mm:ssz", "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd't'HH:mm:ssZ",
+            "yyyy-MM-dd't'HH:mm:ss.SSS'z'","yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'", "yyyy-MM-dd'T'HH:mm:ssz", "yyyy-MM-dd't'HH:mm:ssz", "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd't'HH:mm:ssZ",
             "yyyy-MM-dd'T'HH:mm:ss'Z'", "yyyy-MM-dd't'HH:mm:ss'z'", "yyyy-MM-dd'T'HH:mmz", // together
             // with
             // logic


### PR DESCRIPTION
Unable to parse date with format yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'
this mask added to code