### PR TITLE
Adds support for the Fyyd namespace

### DIFF
--- a/rome-modules/src/main/java/com/rometools/modules/fyyd/io/FyydElement.java
+++ b/rome-modules/src/main/java/com/rometools/modules/fyyd/io/FyydElement.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Maximilian Irro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rometools.modules.fyyd.io;
+
+public interface FyydElement {
+
+    String PREFIX = "fyyd";
+
+    String VERIFY = "verify";
+
+}

--- a/rome-modules/src/main/java/com/rometools/modules/fyyd/io/FyydGenerator.java
+++ b/rome-modules/src/main/java/com/rometools/modules/fyyd/io/FyydGenerator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Maximilian Irro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rometools.modules.fyyd.io;
+
+import com.rometools.modules.fyyd.modules.FyydModule;
+import com.rometools.rome.feed.module.Module;
+import com.rometools.rome.io.ModuleGenerator;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The ModuleGenerator implementation for the Fyyd module.
+ */
+public class FyydGenerator implements ModuleGenerator {
+
+    private static final Namespace NS = Namespace.getNamespace(FyydElement.PREFIX, FyydModule.URI);
+    private static final Set<Namespace> NAMESPACES;
+
+    static {
+        final Set<Namespace> nss = new HashSet<Namespace>();
+        nss.add(NS);
+        NAMESPACES = Collections.unmodifiableSet(nss);
+    }
+
+
+    @Override
+    public String getNamespaceUri() {
+        return FyydModule.URI;
+    }
+
+    @Override
+    public Set<Namespace> getNamespaces() {
+        return NAMESPACES;
+    }
+
+    @Override
+    public void generate(Module module, Element element) {
+        if (module instanceof FyydModule) {
+            final FyydModule fyyd = (FyydModule) module;
+            generateVerify(fyyd.getVerify(), element);
+        }
+    }
+
+    private void generateVerify(String verify, Element parent) {
+        final Element child = new Element(FyydElement.VERIFY, NS);
+        child.setText(verify);
+        parent.addContent(child);
+    }
+
+}

--- a/rome-modules/src/main/java/com/rometools/modules/fyyd/io/FyydParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/fyyd/io/FyydParser.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Maximilian Irro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rometools.modules.fyyd.io;
+
+import com.rometools.modules.fyyd.modules.FyydModule;
+import com.rometools.modules.fyyd.modules.FyydModuleImpl;
+import com.rometools.rome.feed.module.Module;
+import com.rometools.rome.io.ModuleParser;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+
+import java.util.Locale;
+
+/**
+ * The ModuleParser implementation for the Fyyd module.
+ */
+public class FyydParser implements ModuleParser {
+
+    private static final Namespace NS = Namespace.getNamespace(FyydModule.URI);
+
+    @Override
+    public String getNamespaceUri() {
+        return FyydModule.URI;
+    }
+
+    @Override
+    public Module parse(Element element, Locale locale) {
+        if (element.getName().equals("channel") || element.getName().equals("feed")) {
+            final Element verify = element.getChild(FyydElement.VERIFY, NS);
+            if (verify != null && verify.getValue() != null) {
+                final FyydModule fyyd = new FyydModuleImpl();
+                fyyd.setVerify(verify.getValue().trim());
+                return fyyd;
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/rome-modules/src/main/java/com/rometools/modules/fyyd/modules/FyydModule.java
+++ b/rome-modules/src/main/java/com/rometools/modules/fyyd/modules/FyydModule.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Maximilian Irro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rometools.modules.fyyd.modules;
+
+import com.rometools.rome.feed.CopyFrom;
+import com.rometools.rome.feed.module.Module;
+
+/**
+ * This is a ROME module that provides support for the <a href="https://fyyd.de/fyyd-ns/">https://fyyd.de/fyyd-ns/</a> namespace.
+ */
+public interface FyydModule extends Module, CopyFrom {
+
+    /**
+     * The URI of the namespace. (<a href="https://fyyd.de/fyyd-ns/">https://fyyd.de/fyyd-ns/</a>)
+     */
+    String URI = "https://fyyd.de/fyyd-ns/";
+
+    /**
+     * Get the Fyyd verification token.
+     *
+     * @return The Fyyd verification token.
+     */
+    String getVerify();
+
+    /**
+     * Set the Fyyd verification token.
+     *
+     * @param verify The Fyyd verification token.
+     */
+    void setVerify(String verify);
+
+}

--- a/rome-modules/src/main/java/com/rometools/modules/fyyd/modules/FyydModuleImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/fyyd/modules/FyydModuleImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 Maximilian Irro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rometools.modules.fyyd.modules;
+
+import com.rometools.rome.feed.CopyFrom;
+import com.rometools.rome.feed.impl.EqualsBean;
+import com.rometools.rome.feed.impl.ToStringBean;
+import com.rometools.rome.feed.module.ModuleImpl;
+
+import java.io.Serializable;
+
+public class FyydModuleImpl
+        extends ModuleImpl
+        implements FyydModule, Cloneable, Serializable {
+
+    private String verify;
+
+    public FyydModuleImpl() {
+        super(FyydModule.class, FyydModule.URI);
+    }
+
+    @Override
+    public String getVerify() {
+        return this.verify;
+    }
+
+    @Override
+    public void setVerify(String verify) {
+        this.verify = verify;
+    }
+
+    @Override
+    public Class<? extends CopyFrom> getInterface() {
+        return FyydModule.class;
+    }
+
+    @Override
+    public void copyFrom(CopyFrom obj) {
+        final FyydModule mod = (FyydModule) obj;
+        this.setVerify(mod.getVerify());
+    }
+
+    @Override
+    public String getUri() {
+        return FyydModule.URI;
+    }
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        final FyydModuleImpl mod = new FyydModuleImpl();
+        mod.setVerify(this.getVerify());
+        return mod;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBean.beanEquals(FyydModuleImpl.class, this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return EqualsBean.beanHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBean.toString(FyydModuleImpl.class, this);
+    }
+
+}

--- a/rome-modules/src/main/resources/rome.properties
+++ b/rome-modules/src/main/resources/rome.properties
@@ -13,7 +13,8 @@ rss_2.0.feed.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS2 \
     com.rometools.modules.itunes.io.ITunesParserOldNamespace \
     com.rometools.modules.mediarss.io.AlternateMediaModuleParser \
     com.rometools.modules.sle.io.ModuleParser \
-    com.rometools.modules.yahooweather.io.WeatherModuleParser
+    com.rometools.modules.yahooweather.io.WeatherModuleParser \
+    com.rometools.modules.fyyd.io.FyydParser
 
 rss_1.0.feed.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS1 \
     com.rometools.modules.content.io.ContentModuleParser
@@ -32,7 +33,8 @@ atom_1.0.feed.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS2 
     com.rometools.modules.georss.W3CGeoParser \
     com.rometools.modules.photocast.io.Parser \
     com.rometools.modules.mediarss.io.MediaModuleParser \
-    com.rometools.modules.mediarss.io.AlternateMediaModuleParser
+    com.rometools.modules.mediarss.io.AlternateMediaModuleParser \
+    com.rometools.modules.fyyd.io.FyydParser
 
 rss_2.0.item.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS2 \
     com.rometools.modules.base.io.GoogleBaseParser \
@@ -93,7 +95,8 @@ rss_2.0.feed.ModuleGenerator.classes=com.rometools.modules.cc.io.CCModuleGenerat
     com.rometools.modules.mediarss.io.MediaModuleGenerator \
     com.rometools.modules.atom.io.AtomModuleGenerator \
     com.rometools.modules.sle.io.ModuleGenerator \
-    com.rometools.modules.yahooweather.io.WeatherModuleGenerator
+    com.rometools.modules.yahooweather.io.WeatherModuleGenerator \
+    com.rometools.modules.fyyd.io.FyydGenerator
 
 rss_1.0.feed.ModuleGenerator.classes=com.rometools.modules.content.io.ContentModuleGenerator
 
@@ -109,7 +112,8 @@ atom_1.0.feed.ModuleGenerator.classes=com.rometools.modules.cc.io.CCModuleGenera
     com.rometools.modules.georss.SimpleGenerator \
     com.rometools.modules.georss.W3CGeoGenerator \
     com.rometools.modules.photocast.io.Generator \
-    com.rometools.modules.mediarss.io.MediaModuleGenerator
+    com.rometools.modules.mediarss.io.MediaModuleGenerator \
+    com.rometools.modules.fyyd.io.FyydGenerator
 
 rss_2.0.item.ModuleGenerator.classes=com.rometools.modules.cc.io.CCModuleGenerator \
     com.rometools.modules.base.io.GoogleBaseGenerator \

--- a/rome-modules/src/test/java/com/rometools/modules/fyyd/FyydGeneratorTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/fyyd/FyydGeneratorTest.java
@@ -1,0 +1,80 @@
+package com.rometools.modules.fyyd;
+
+import com.rometools.modules.AbstractTestCase;
+import com.rometools.modules.fyyd.io.FyydGenerator;
+import com.rometools.modules.fyyd.modules.FyydModule;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.SyndFeedInput;
+import com.rometools.rome.io.SyndFeedOutput;
+import com.rometools.rome.io.XmlReader;
+import junit.framework.TestSuite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.StringWriter;
+
+public class FyydGeneratorTest extends AbstractTestCase {
+
+    private static final Logger log = LoggerFactory.getLogger(FyydGeneratorTest.class);
+
+    public FyydGeneratorTest(final String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected void setUp() {
+    }
+
+    @Override
+    protected void tearDown() {
+    }
+
+    public static junit.framework.Test suite() {
+        return new TestSuite(FyydGeneratorTest.class);
+    }
+
+    public void testGenerateRss() throws Exception {
+
+        log.debug("testGenerateRss");
+
+        final SyndFeedInput input = new SyndFeedInput();
+        final SyndFeed feed = input.build(new XmlReader(new File(getTestFile("fyyd/rss.xml")).toURI().toURL()));
+        feed.getModule(FyydModule.URI);
+        final SyndFeedOutput output = new SyndFeedOutput();
+        final StringWriter writer = new StringWriter();
+        output.output(feed, writer);
+
+        final String xml = writer.toString();
+        assertTrue(xml.contains("xmlns:fyyd=\"https://fyyd.de/fyyd-ns/\""));
+        assertTrue(xml.contains("<fyyd:verify>abcdefg</fyyd:verify>"));
+
+        log.debug("{}", writer);
+
+    }
+
+    public void testGenerateAtom() throws Exception {
+
+        log.debug("testGenerateAtom");
+
+        final SyndFeedInput input = new SyndFeedInput();
+        final SyndFeed feed = input.build(new XmlReader(new File(getTestFile("fyyd/atom.xml")).toURI().toURL()));
+        feed.getModule(FyydModule.URI);
+        final SyndFeedOutput output = new SyndFeedOutput();
+        final StringWriter writer = new StringWriter();
+        output.output(feed, writer);
+
+        final String xml = writer.toString();
+        assertTrue(xml.contains("xmlns:fyyd=\"https://fyyd.de/fyyd-ns/\""));
+        assertTrue(xml.contains("<fyyd:verify>abcdefg</fyyd:verify>"));
+
+        log.debug("{}", writer);
+
+    }
+
+    public void testGetNamespaceUri() {
+        assertEquals("Namespace", FyydModule.URI, new FyydGenerator().getNamespaceUri());
+    }
+
+
+}

--- a/rome-modules/src/test/java/com/rometools/modules/fyyd/FyydParserTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/fyyd/FyydParserTest.java
@@ -1,0 +1,63 @@
+package com.rometools.modules.fyyd;
+
+import com.rometools.modules.AbstractTestCase;
+import com.rometools.modules.fyyd.io.FyydParser;
+import com.rometools.modules.fyyd.modules.FyydModule;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.SyndFeedInput;
+import com.rometools.rome.io.XmlReader;
+import junit.framework.TestSuite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+public class FyydParserTest extends AbstractTestCase {
+
+    private static final Logger log = LoggerFactory.getLogger(FyydParserTest.class);
+
+    public FyydParserTest(final String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected void setUp() {
+    }
+
+    @Override
+    protected void tearDown() {
+    }
+
+    public static junit.framework.Test suite() {
+        return new TestSuite(FyydParserTest.class);
+    }
+
+    public void testParseRss() throws Exception {
+
+        log.debug("testParseRss");
+
+        final SyndFeedInput input = new SyndFeedInput();
+        final SyndFeed feed = input.build(new XmlReader(new File(getTestFile("fyyd/rss.xml")).toURI().toURL()));
+        final FyydModule fyyd = (FyydModule) feed.getModule(FyydModule.URI);
+
+        assertNotNull(fyyd);
+        assertEquals("abcdefg", fyyd.getVerify());
+    }
+
+    public void testParseAtom() throws Exception {
+
+        log.debug("testParseAtom");
+
+        final SyndFeedInput input = new SyndFeedInput();
+        final SyndFeed feed = input.build(new XmlReader(new File(getTestFile("fyyd/atom.xml")).toURI().toURL()));
+        final FyydModule fyyd = (FyydModule) feed.getModule(FyydModule.URI);
+
+        assertNotNull(fyyd);
+        assertEquals("abcdefg", fyyd.getVerify());
+    }
+
+    public void testGetNamespaceUri() {
+        assertEquals("Namespace", FyydModule.URI, new FyydParser().getNamespaceUri());
+    }
+
+}

--- a/rome-modules/src/test/resources/fyyd/atom.xml
+++ b/rome-modules/src/test/resources/fyyd/atom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:fyyd="https://fyyd.de/fyyd-ns/">
+    <title>Lorem Ipsum</title>
+    <link href="http://example.org"/>
+    <fyyd:verify>abcdefg</fyyd:verify>
+    <entry>
+        <title>Lorem Ipsum</title>
+        <link href="http://example.org/episode1"/>
+        <link rel="enclosure"
+              href="http://example.org/episode1.m4a" />
+    </entry>
+</feed>

--- a/rome-modules/src/test/resources/fyyd/rss.xml
+++ b/rome-modules/src/test/resources/fyyd/rss.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:fyyd="https://fyyd.de/fyyd-ns/" version="2.0">
+    <channel>
+        <title>Lorem Ipsum</title>
+        <link>http://example.org</link>
+        <description>Lorem Ipsum</description>
+        <fyyd:verify>abcdefg</fyyd:verify>
+        <item>
+            <title>Lorem Ipsum</title>
+            <link>http://example.org/episode1</link>
+            <description><![CDATA[Lorem Ipsum]]></description>
+        </item>
+    </channel>
+</rss>


### PR DESCRIPTION
This module adds support for the Fyyd namespace `https://fyyd.de/fyyd-ns/` that is used to claim feeds on the [Fyyd](https://fyyd.de) podcast directory. Includes parser and generator implementation, as well as unit tests for RSS and Atom feeds.