### PR TITLE
Improves the Podlove Simple Chapter module

### DIFF
--- a/rome-modules/src/main/resources/rome.properties
+++ b/rome-modules/src/main/resources/rome.properties
@@ -55,8 +55,7 @@ rss_1.0.item.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS1 \
     com.rometools.modules.base.io.GoogleBaseParser \
     com.rometools.modules.base.io.CustomTagParser \
     com.rometools.modules.content.io.ContentModuleParser \
-    com.rometools.modules.slash.io.SlashModuleParser \
-    com.rometools.modules.psc.io.PodloveSimpleChapterParser
+    com.rometools.modules.slash.io.SlashModuleParser
 
 atom_0.3.item.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS2 \
     com.rometools.modules.base.io.GoogleBaseParser \
@@ -67,8 +66,7 @@ atom_0.3.item.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS2 
     com.rometools.modules.georss.W3CGeoParser \
     com.rometools.modules.photocast.io.Parser \
     com.rometools.modules.mediarss.io.MediaModuleParser \
-    com.rometools.modules.mediarss.io.AlternateMediaModuleParser \
-    com.rometools.modules.psc.io.PodloveSimpleChapterParser
+    com.rometools.modules.mediarss.io.AlternateMediaModuleParser
 
 atom_1.0.item.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS2 \
     com.rometools.modules.base.io.GoogleBaseParser \
@@ -123,12 +121,12 @@ rss_2.0.item.ModuleGenerator.classes=com.rometools.modules.cc.io.CCModuleGenerat
     com.rometools.modules.photocast.io.Generator \
     com.rometools.modules.mediarss.io.MediaModuleGenerator \
     com.rometools.modules.atom.io.AtomModuleGenerator \
-    com.rometools.modules.yahooweather.io.WeatherModuleGenerator
+    com.rometools.modules.yahooweather.io.WeatherModuleGenerator \
+    com.rometools.modules.psc.io.PodloveSimpleChapterGenerator
 
 rss_1.0.item.ModuleGenerator.classes=com.rometools.modules.base.io.GoogleBaseGenerator \
     com.rometools.modules.content.io.ContentModuleGenerator \
-    com.rometools.modules.slash.io.SlashModuleGenerator \
-    com.rometools.modules.psc.io.PodloveSimpleChapterGenerator
+    com.rometools.modules.slash.io.SlashModuleGenerator
 
 atom_0.3.item.ModuleGenerator.classes=com.rometools.modules.cc.io.CCModuleGenerator \
     com.rometools.modules.base.io.GoogleBaseGenerator \
@@ -138,8 +136,7 @@ atom_0.3.item.ModuleGenerator.classes=com.rometools.modules.cc.io.CCModuleGenera
     com.rometools.modules.georss.SimpleGenerator \
     com.rometools.modules.georss.W3CGeoGenerator \
     com.rometools.modules.photocast.io.Generator \
-    com.rometools.modules.mediarss.io.MediaModuleGenerator \
-    com.rometools.modules.psc.io.PodloveSimpleChapterGenerator
+    com.rometools.modules.mediarss.io.MediaModuleGenerator
 
 atom_1.0.item.ModuleGenerator.classes=com.rometools.modules.cc.io.CCModuleGenerator \
     com.rometools.modules.base.io.CustomTagGenerator \

--- a/rome-modules/src/test/java/com/rometools/modules/psc/PodloveSimpleChapterGeneratorTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/psc/PodloveSimpleChapterGeneratorTest.java
@@ -35,24 +35,44 @@ public class PodloveSimpleChapterGeneratorTest extends AbstractTestCase {
         return new TestSuite(PodloveSimpleChapterGeneratorTest.class);
     }
 
-    public void testGenerate() throws Exception {
+    public void testGenerateRss() throws Exception {
 
-        log.debug("testGenerate");
+        log.debug("testGenerateRss");
 
         final SyndFeedInput input = new SyndFeedInput();
-        final SyndFeed feed = input.build(new XmlReader(new File(getTestFile("psc/test1.xml")).toURI().toURL()));
+        final SyndFeed feed = input.build(new XmlReader(new File(getTestFile("psc/rss.xml")).toURI().toURL()));
         final SyndEntry entry = feed.getEntries().get(0);
         entry.getModule(PodloveSimpleChapterModule.URI);
         final SyndFeedOutput output = new SyndFeedOutput();
         final StringWriter writer = new StringWriter();
         output.output(feed, writer);
 
+        final String xml = writer.toString();
         log.debug("{}", writer);
 
+        assertTrue(xml.contains("xmlns:psc=\"http://podlove.org/simple-chapters\""));
+        assertTrue(xml.contains("<psc:chapters version=\"1.2\">"));
+        assertTrue(xml.contains("<psc:chapter start=\"00:00:00.000\" title=\"Lorem Ipsum\" href=\"http://example.org\" image=\"http://example.org/cover\" />"));
     }
 
-    public void testGetNamespaces() {
-        // TODO add test code
+    public void testGenerateAtom() throws Exception {
+
+        log.debug("testGenerateAtom");
+
+        final SyndFeedInput input = new SyndFeedInput();
+        final SyndFeed feed = input.build(new XmlReader(new File(getTestFile("psc/atom.xml")).toURI().toURL()));
+        final SyndEntry entry = feed.getEntries().get(0);
+        entry.getModule(PodloveSimpleChapterModule.URI);
+        final SyndFeedOutput output = new SyndFeedOutput();
+        final StringWriter writer = new StringWriter();
+        output.output(feed, writer);
+
+        final String xml = writer.toString();
+        log.debug("{}", writer);
+
+        assertTrue(xml.contains("xmlns:psc=\"http://podlove.org/simple-chapters\""));
+        assertTrue(xml.contains("<psc:chapters version=\"1.2\">"));
+        assertTrue(xml.contains("<psc:chapter start=\"00:00:00.000\" title=\"Lorem Ipsum\" href=\"http://example.org\" image=\"http://example.org/cover\" />"));
     }
 
     public void testGetNamespaceUri() {

--- a/rome-modules/src/test/java/com/rometools/modules/psc/PodloveSimpleChapterParserTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/psc/PodloveSimpleChapterParserTest.java
@@ -34,22 +34,40 @@ public class PodloveSimpleChapterParserTest extends AbstractTestCase {
         return new TestSuite(PodloveSimpleChapterParserTest.class);
     }
 
-    public void testParse() throws Exception {
+    public void testParseRss() throws Exception {
 
-        log.debug("testParse");
+        log.debug("testParseRss");
 
         final SyndFeedInput input = new SyndFeedInput();
-        final SyndFeed feed = input.build(new XmlReader(new File(getTestFile("psc/test1.xml")).toURI().toURL()));
+        final SyndFeed feed = input.build(new XmlReader(new File(getTestFile("psc/rss.xml")).toURI().toURL()));
         final SyndEntry entry = feed.getEntries().get(0);
-        final PodloveSimpleChapterModule module = (PodloveSimpleChapterModule) entry.getModule(PodloveSimpleChapterModule.URI);
+        final PodloveSimpleChapterModule simpleChapters = (PodloveSimpleChapterModule) entry.getModule(PodloveSimpleChapterModule.URI);
 
-        for (SimpleChapter c : module.getChapters()) {
+        assertNotNull(simpleChapters);
+        for (SimpleChapter c : simpleChapters.getChapters()) {
             assertEquals("00:00:00.000", c.getStart());
             assertEquals("Lorem Ipsum", c.getTitle());
             assertEquals("http://example.org", c.getHref());
             assertEquals("http://example.org/cover", c.getImage());
         }
+    }
 
+    public void testParseAtom() throws Exception {
+
+        log.debug("testParseAtom");
+
+        final SyndFeedInput input = new SyndFeedInput();
+        final SyndFeed feed = input.build(new XmlReader(new File(getTestFile("psc/atom.xml")).toURI().toURL()));
+        final SyndEntry entry = feed.getEntries().get(0);
+        final PodloveSimpleChapterModule simpleChapters = (PodloveSimpleChapterModule) entry.getModule(PodloveSimpleChapterModule.URI);
+
+        assertNotNull(simpleChapters);
+        for (SimpleChapter c : simpleChapters.getChapters()) {
+            assertEquals("00:00:00.000", c.getStart());
+            assertEquals("Lorem Ipsum", c.getTitle());
+            assertEquals("http://example.org", c.getHref());
+            assertEquals("http://example.org/cover", c.getImage());
+        }
     }
 
     public void testGetNamespaceUri() {

--- a/rome-modules/src/test/resources/psc/atom.xml
+++ b/rome-modules/src/test/resources/psc/atom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:psc="http://podlove.org/simple-chapters">
+    <title>Lorem Ipsum</title>
+    <link href="http://example.org"/>
+    <entry>
+        <title>Lorem Ipsum</title>
+        <link href="http://example.org/episode1"/>
+        <link rel="enclosure"
+              href="http://example.org/episode1.m4a" />
+        <psc:chapters version="1.2">
+            <psc:chapter start="00:00:00.000" title="Lorem Ipsum" href="http://example.org" image="http://example.org/cover"/>
+            <psc:chapter start="00:00:00.000" title="Lorem Ipsum" href="http://example.org" image="http://example.org/cover"/>
+            <psc:chapter start="00:00:00.000" title="Lorem Ipsum" href="http://example.org" image="http://example.org/cover"/>
+        </psc:chapters>
+    </entry>
+</feed>

--- a/rome-modules/src/test/resources/psc/rss.xml
+++ b/rome-modules/src/test/resources/psc/rss.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" media="screen" href="/~files/feed-premium.xsl"?>
-
 <rss xmlns:psc="http://podlove.org/simple-chapters" version="2.0">
     <channel>
         <title>Lorem Ipsum</title>
@@ -10,7 +8,7 @@
             <title>Lorem Ipsum</title>
             <link>http://example.org/episode1</link>
             <description><![CDATA[Lorem Ipsum]]></description>
-            <psc:chapters xmlns:psc="http://podlove.org/simple-chapters" version="1.2">
+            <psc:chapters version="1.2">
                 <psc:chapter start="00:00:00.000" title="Lorem Ipsum" href="http://example.org" image="http://example.org/cover"/>
                 <psc:chapter start="00:00:00.000" title="Lorem Ipsum" href="http://example.org" image="http://example.org/cover"/>
                 <psc:chapter start="00:00:00.000" title="Lorem Ipsum" href="http://example.org" image="http://example.org/cover"/>


### PR DESCRIPTION
This PR improves the existing Podlove Simple Chapter module. It extends the unit tests, and enables the module for RSS 2.0 and Atom 1.0 feeds only, since the XML namespaces is intended only for podcast feeds. 