### PR TITLE
resolves #428 by trimming the datetime mask

### DIFF
--- a/rome/pom.xml
+++ b/rome/pom.xml
@@ -69,6 +69,38 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <!-- mvn spotbugs:spotbugs spotbugs:gui -->
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>3.1.11</version>
+                <dependencies>
+                    <!-- overwrite dependency on spotbugs if you want to specify the version 
+                        of spotbugs -->
+                    <dependency>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs</artifactId>
+                        <version>3.1.12</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <!-- mvn verify -->
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>5.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <format>xml</format>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
         </plugins>
     </build>
 
@@ -100,6 +132,12 @@
             <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.11.1</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
 </project>

--- a/rome/src/main/java/com/rometools/rome/io/impl/DateParser.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/DateParser.java
@@ -227,12 +227,16 @@ public class DateParser {
      *
      * */
     public static Date parseDate(final String sDate, final Locale locale) {
-        Date date = parseW3CDateTime(sDate, locale);
+    	Date date = null;
+    	if (ADDITIONAL_MASKS.length > 0) {
+    		date = parseUsingMask(ADDITIONAL_MASKS, sDate, locale);
+    		if (date != null) {
+    			return date;
+    		}
+    	}
+        date = parseW3CDateTime(sDate, locale);
         if (date == null) {
             date = parseRFC822(sDate, locale);
-            if (date == null && ADDITIONAL_MASKS.length > 0) {
-                date = parseUsingMask(ADDITIONAL_MASKS, sDate, locale);
-            }
         }
         return date;
     }

--- a/rome/src/main/java/com/rometools/rome/io/impl/DateParser.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/DateParser.java
@@ -104,7 +104,7 @@ public class DateParser {
         ParsePosition pp = null;
         Date d = null;
         for (int i = 0; d == null && i < masks.length; i++) {
-            final DateFormat df = new SimpleDateFormat(masks[i], locale);
+            final DateFormat df = new SimpleDateFormat(masks[i].trim(), locale);
             // df.setLenient(false);
             df.setLenient(true);
             try {

--- a/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
+++ b/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
@@ -1,0 +1,51 @@
+package com.rometools.rome.io.impl;
+
+import static org.assertj.core.api.Assertions.*;
+import java.util.Date;
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link DateParser}.
+ * 
+ * @author <a href="mailto:lutz.horn@posteo.de">Lutz Horn</a>
+ *
+ */
+public class DateParserTest {
+
+	@Before
+	public void before() {
+	}
+
+	@After
+	public void after() {
+	}
+
+	@Test
+	public void parseW3CDateTimeIsOk() {
+		Date result = DateParser.parseW3CDateTime("2019-06-07T15:27:13+02:00", Locale.GERMANY);
+
+		assertDateFields(result);
+	}
+
+	@Test
+	public void parseW3CDateTimeWithTrailingWhitespaceIsOk() {
+		Date result = DateParser.parseW3CDateTime("2019-06-07T15:27:13+02:00    ", Locale.GERMANY);
+
+		assertDateFields(result);
+	}
+
+	private void assertDateFields(Date result) {
+		assertThat(result).isNotNull();
+		assertThat(result).hasYear(2019);
+		assertThat(result).hasMonth(6);
+		assertThat(result).hasDayOfMonth(7);
+		assertThat(result).hasHourOfDay(15);
+		assertThat(result).hasMinute(27);
+		assertThat(result).hasSecond(13);
+	}
+
+}


### PR DESCRIPTION
This PR uses `.trim()` on each mask from `datetime.extra.masks`.

It also adds the beginning of `DateParserTest` plus the Maven plugins `spotbugs-maven-plugin` and `dependency-check-maven`.