### PR TITLE
Allow zero lengths for enclosures

### DIFF
--- a/rome/src/main/java/com/rometools/rome/feed/rss/Enclosure.java
+++ b/rome/src/main/java/com/rometools/rome/feed/rss/Enclosure.java
@@ -30,7 +30,7 @@ import com.rometools.rome.feed.impl.ToStringBean;
 public class Enclosure implements Cloneable, Serializable {
     private static final long serialVersionUID = 1L;
     private String url;
-    private long length;
+    private long length = -1L;
     private String type;
 
     public Enclosure() { }

--- a/rome/src/main/java/com/rometools/rome/io/impl/RSS092Generator.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/RSS092Generator.java
@@ -142,7 +142,7 @@ public class RSS092Generator extends RSS091UserlandGenerator {
         }
 
         final long length = enclosure.getLength();
-        if (length != 0) {
+        if (length > -1L) {
             enclosureElement.setAttribute("length", String.valueOf(length));
         }
 


### PR DESCRIPTION
RSS specification says length is required, and 0 is the recommended value when you don't know the actual length