### PR TITLE
Fixed #441

### DIFF
--- a/rome/src/main/java/com/rometools/rome/io/impl/DateParser.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/DateParser.java
@@ -153,7 +153,6 @@ public class DateParser {
     	List<String> splitted = Arrays.asList(sDate.split(" "));
         for (String timeZone : unsupportedZeroOffsetTimeZones) {
             if (splitted.contains(timeZone)) {
-//        	if (sDate.endsWith(timeZone)) {
                 return replaceLastOccurrence(sDate, timeZone, "UTC");
             }
         }

--- a/rome/src/main/java/com/rometools/rome/io/impl/DateParser.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/DateParser.java
@@ -150,8 +150,10 @@ public class DateParser {
     private static String convertUnsupportedTimeZones(String sDate) {
         final List<String> unsupportedZeroOffsetTimeZones = Arrays.asList("UT", "Z");
 
+    	List<String> splitted = Arrays.asList(sDate.split(" "));
         for (String timeZone : unsupportedZeroOffsetTimeZones) {
-            if (sDate.endsWith(timeZone)) {
+            if (splitted.contains(timeZone)) {
+//        	if (sDate.endsWith(timeZone)) {
                 return replaceLastOccurrence(sDate, timeZone, "UTC");
             }
         }

--- a/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
+++ b/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
@@ -2,8 +2,11 @@ package com.rometools.rome.io.impl;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
+
 import org.junit.Test;
 
 public class DateParserTest {
@@ -21,6 +24,20 @@ public class DateParserTest {
         assertEquals(
                 new Date(1000),
                 DateParser.parseW3CDateTime("1970-01-01T00:00:01+00:00   ", Locale.GERMANY)
+        );
+    }
+    
+    @Test
+    public void parseRFC822DateTimeWithTimeZoneIsOk() throws Exception {
+    	// Sat, 28 Mar 2020 13:42:38 IST
+    	Calendar c = Calendar.getInstance();
+    	c.set(2020, 2, 28, 13, 42, 38);
+    	c.clear(Calendar.MILLISECOND);
+    	c.setTimeZone(TimeZone.getTimeZone("IST"));
+    	
+    	assertEquals(
+                c.getTime(),
+                DateParser.parseRFC822("Sa, 28 Mär 20 09:12:38 MEZ", Locale.GERMANY)
         );
     }
 }


### PR DESCRIPTION
Fixed #441 

In my opinion, IST is a supported time zone and conforms a parseable RFC 822 date. Maybe is not the best solution (I saw a complete DateParser's pull request before), but this one is valid to fix the issue.

Regards!