### PR TITLE
Add a field for itunes image as URI 

### DIFF
--- a/rome-modules/src/main/java/com/rometools/modules/itunes/AbstractITunesObject.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/AbstractITunesObject.java
@@ -16,6 +16,7 @@
  */
 package com.rometools.modules.itunes;
 
+import java.net.URI;
 import java.net.URL;
 
 /**
@@ -47,6 +48,7 @@ public abstract class AbstractITunesObject implements ITunes, java.lang.Cloneabl
     private boolean block;
     private Boolean explicit;
     private URL image;
+    private URI imageUri;
     private String[] keywords;
     private String subtitle;
     private String summary;
@@ -224,6 +226,16 @@ public abstract class AbstractITunesObject implements ITunes, java.lang.Cloneabl
     }
 
     @Override
+    public URI getImageUri() {
+        return imageUri;
+    }
+
+    @Override
+    public void setImageUri(final URI image) {
+        this.imageUri = image;
+    }
+
+    @Override
     public String toString() {
         final StringBuffer sb = new StringBuffer("[");
         sb.append(" Author: ");
@@ -233,7 +245,7 @@ public abstract class AbstractITunesObject implements ITunes, java.lang.Cloneabl
         sb.append(" Explicit: ");
         sb.append(getExplicitNullable());
         sb.append(" Image: ");
-        sb.append(getImage());
+        sb.append(getImageUri());
         sb.append(" Keywords: ");
 
         if (getKeywords() != null) {

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformationImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformationImpl.java
@@ -19,6 +19,7 @@ package com.rometools.modules.itunes;
 import com.rometools.modules.itunes.types.Duration;
 import com.rometools.rome.feed.CopyFrom;
 
+import java.net.URISyntaxException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -140,12 +141,20 @@ public class EntryInformationImpl extends AbstractITunesObject implements EntryI
 
         setExplicitNullable(info.getExplicitNullable());
 
-        try {
-            if (info.getImage() != null) {
+        if (info.getImage() != null) {
+            try {
                 setImage(new URL(info.getImage().toExternalForm()));
+            } catch (final MalformedURLException e) {
+                LOG.debug("Error copying URL:" + info.getImage(), e);
             }
-        } catch (final MalformedURLException e) {
-            LOG.debug("Error copying URL:" + info.getImage(), e);
+        }
+
+        if (info.getImageUri() != null) {
+            try {
+                setImageUri(new java.net.URI(info.getImageUri().toString()));
+            } catch (final URISyntaxException  e) {
+                LOG.debug("Error copying URI:" + info.getImageUri(), e);
+            }
         }
 
         if (info.getKeywords() != null) {

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/FeedInformationImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/FeedInformationImpl.java
@@ -17,6 +17,7 @@
 package com.rometools.modules.itunes;
 
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -162,12 +163,20 @@ public class FeedInformationImpl extends AbstractITunesObject implements FeedInf
         setNewFeedUrl(info.getNewFeedUrl());
         setExplicitNullable(info.getExplicitNullable());
 
-        try {
-            if (info.getImage() != null) {
+        if (info.getImage() != null) {
+            try {
                 setImage(new URL(info.getImage().toExternalForm()));
+            } catch (final MalformedURLException e) {
+                LOG.debug("Error copying URL:" + info.getImage(), e);
             }
-        } catch (final MalformedURLException e) {
-            LOG.debug("Error copying URL:" + info.getImage(), e);
+        }
+
+        if (info.getImageUri() != null) {
+            try {
+                setImageUri(new java.net.URI(info.getImageUri().toString()));
+            } catch (final URISyntaxException  e) {
+                LOG.debug("Error copying URI:" + info.getImageUri(), e);
+            }
         }
 
         if (info.getKeywords() != null) {

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/ITunes.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/ITunes.java
@@ -18,6 +18,7 @@ package com.rometools.modules.itunes;
 
 import com.rometools.rome.feed.module.Module;
 
+import java.net.URI;
 import java.net.URL;
 
 /**
@@ -123,4 +124,7 @@ public interface ITunes extends Module {
      */
     public void setSummary(String summary);
 
+    public java.net.URI getImageUri();
+
+    public void setImageUri(java.net.URI image);
 }

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesGenerator.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesGenerator.java
@@ -141,7 +141,7 @@ public class ITunesGenerator implements ModuleGenerator {
 
         if (itunes.getImage() != null) {
             final Element image = generateSimpleElement("image", "");
-            image.setAttribute("href", itunes.getImage().toExternalForm());
+            image.setAttribute("href", itunes.getImageUri().toString());
             element.addContent(image);
         }
 

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
@@ -17,6 +17,8 @@
 package com.rometools.modules.itunes.io;
 
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
@@ -250,6 +252,13 @@ public class ITunesParser implements ModuleParser {
                     module.setImage(imageURL);
                 } catch (final MalformedURLException e) {
                     LOG.warn("Malformed URL Exception reading itunes:image tag: {}", image.getAttributeValue("href"));
+                }
+
+                try {
+                    final URI imageUri = new URI(image.getAttributeValue("href").trim());
+                    module.setImageUri(imageUri);
+                } catch (final URISyntaxException  e) {
+                    LOG.warn("URISyntaxException reading itunes:image tag: {}", image.getAttributeValue("href"));
                 }
             }
         }

--- a/rome-modules/src/test/java/com/rometools/modules/itunes/ITunesParserTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/itunes/ITunesParserTest.java
@@ -20,6 +20,7 @@
 package com.rometools.modules.itunes;
 
 import java.io.File;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -199,5 +200,20 @@ public class ITunesParserTest extends AbstractTestCase {
 
             assertFalse(module.getExplicitNullable());
         }
+    }
+
+    public void testParseNonHttpUris() throws Exception {
+        File feed = new File(getTestFile("itunes/no-http-uris.xml"));
+        final SyndFeedInput input = new SyndFeedInput();
+        SyndFeed syndfeed = input.build(new XmlReader(feed.toURI().toURL()));
+
+        final FeedInformationImpl feedInfo = (FeedInformationImpl) syndfeed.getModule(AbstractITunesObject.URI);
+
+        assertEquals(URI.create("file://some-location/1.jpg"), feedInfo.getImageUri());
+
+        SyndEntry entry = syndfeed.getEntries().get(0);
+        EntryInformationImpl module = (EntryInformationImpl) entry.getModule(AbstractITunesObject.URI);
+
+        assertEquals(URI.create("gs://some-location/2.jpg"), module.getImageUri());
     }
 }


### PR DESCRIPTION
Unfortunately URL is not very good at some types of uri, for example
gs://
This adds an extra field using URI.
There are other places where rome uses URI instead of URL so this can be
a step closer to more consistent usage of URI.