### PR TITLE
Change ITunes imageUri field type to String

### DIFF
--- a/rome-modules/src/main/java/com/rometools/modules/itunes/AbstractITunesObject.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/AbstractITunesObject.java
@@ -16,7 +16,6 @@
  */
 package com.rometools.modules.itunes;
 
-import java.net.URI;
 import java.net.URL;
 
 /**
@@ -48,7 +47,7 @@ public abstract class AbstractITunesObject implements ITunes, java.lang.Cloneabl
     private boolean block;
     private Boolean explicit;
     private URL image;
-    private URI imageUri;
+    private String imageUri;
     private String[] keywords;
     private String subtitle;
     private String summary;
@@ -226,12 +225,12 @@ public abstract class AbstractITunesObject implements ITunes, java.lang.Cloneabl
     }
 
     @Override
-    public URI getImageUri() {
+    public String getImageUri() {
         return imageUri;
     }
 
     @Override
-    public void setImageUri(final URI image) {
+    public void setImageUri(final String image) {
         this.imageUri = image;
     }
 

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformationImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/EntryInformationImpl.java
@@ -150,11 +150,7 @@ public class EntryInformationImpl extends AbstractITunesObject implements EntryI
         }
 
         if (info.getImageUri() != null) {
-            try {
-                setImageUri(new java.net.URI(info.getImageUri().toString()));
-            } catch (final URISyntaxException  e) {
-                LOG.debug("Error copying URI:" + info.getImageUri(), e);
-            }
+            setImageUri(info.getImageUri());
         }
 
         if (info.getKeywords() != null) {

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/FeedInformationImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/FeedInformationImpl.java
@@ -172,11 +172,7 @@ public class FeedInformationImpl extends AbstractITunesObject implements FeedInf
         }
 
         if (info.getImageUri() != null) {
-            try {
-                setImageUri(new java.net.URI(info.getImageUri().toString()));
-            } catch (final URISyntaxException  e) {
-                LOG.debug("Error copying URI:" + info.getImageUri(), e);
-            }
+            setImageUri(info.getImageUri());
         }
 
         if (info.getKeywords() != null) {

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/ITunes.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/ITunes.java
@@ -18,7 +18,6 @@ package com.rometools.modules.itunes;
 
 import com.rometools.rome.feed.module.Module;
 
-import java.net.URI;
 import java.net.URL;
 
 /**
@@ -124,7 +123,7 @@ public interface ITunes extends Module {
      */
     public void setSummary(String summary);
 
-    public java.net.URI getImageUri();
+    public String getImageUri();
 
-    public void setImageUri(java.net.URI image);
+    public void setImageUri(String image);
 }

--- a/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
@@ -254,12 +254,7 @@ public class ITunesParser implements ModuleParser {
                     LOG.warn("Malformed URL Exception reading itunes:image tag: {}", image.getAttributeValue("href"));
                 }
 
-                try {
-                    final URI imageUri = new URI(image.getAttributeValue("href").trim());
-                    module.setImageUri(imageUri);
-                } catch (final URISyntaxException  e) {
-                    LOG.warn("URISyntaxException reading itunes:image tag: {}", image.getAttributeValue("href"));
-                }
+                module.setImageUri(image.getAttributeValue("href").trim());
             }
         }
 

--- a/rome-modules/src/test/java/com/rometools/modules/itunes/ITunesGeneratorTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/itunes/ITunesGeneratorTest.java
@@ -130,8 +130,7 @@ public class ITunesGeneratorTest extends AbstractTestCase {
                         .build(new XmlReader(new ByteArrayInputStream(xml.getBytes("UTF-8"))))
                         .getModule(AbstractITunesObject.URI);
         assertEquals(new URL("https://example.org/test.png"), parsedItunesFeed.getImage());
-        assertEquals(new java.net.URI("https://example.org/test.png"),
-                parsedItunesFeed.getImageUri());
+        assertEquals("https://example.org/test.png", parsedItunesFeed.getImageUri());
     }
 
     public void testImageUri() throws Exception {
@@ -142,7 +141,7 @@ public class ITunesGeneratorTest extends AbstractTestCase {
         feed.setLink("https://example.org");
 
         FeedInformation itunesFeed = new FeedInformationImpl();
-        itunesFeed.setImageUri(new java.net.URI("https://example.org/test.png"));
+        itunesFeed.setImageUri("https://example.org/test.png");
         feed.getModules().add(itunesFeed);
 
         String xml = new SyndFeedOutput().outputString(feed);
@@ -151,7 +150,7 @@ public class ITunesGeneratorTest extends AbstractTestCase {
                 (AbstractITunesObject) new SyndFeedInput()
                         .build(new XmlReader(new ByteArrayInputStream(xml.getBytes("UTF-8"))))
                         .getModule(AbstractITunesObject.URI);
-        assertEquals(new java.net.URI("https://example.org/test.png"),
+        assertEquals("https://example.org/test.png",
                 parsedItunesFeed.getImageUri());
         assertEquals(new URL("https://example.org/test.png"),
                 parsedItunesFeed.getImage());
@@ -166,7 +165,7 @@ public class ITunesGeneratorTest extends AbstractTestCase {
 
         FeedInformation itunesFeed = new FeedInformationImpl();
         itunesFeed.setImage(new URL("https://example.org/test1.png"));
-        itunesFeed.setImageUri(new java.net.URI("https://example.org/test2.png"));
+        itunesFeed.setImageUri("https://example.org/test2.png");
         feed.getModules().add(itunesFeed);
 
         String xml = new SyndFeedOutput().outputString(feed);
@@ -176,7 +175,6 @@ public class ITunesGeneratorTest extends AbstractTestCase {
                         .build(new XmlReader(new ByteArrayInputStream(xml.getBytes("UTF-8"))))
                         .getModule(AbstractITunesObject.URI);
         assertEquals(new URL("https://example.org/test1.png"), parsedItunesFeed.getImage());
-        assertEquals(new java.net.URI("https://example.org/test1.png"),
-                parsedItunesFeed.getImageUri());
+        assertEquals("https://example.org/test1.png", parsedItunesFeed.getImageUri());
     }
 }

--- a/rome-modules/src/test/java/com/rometools/modules/itunes/ITunesParserTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/itunes/ITunesParserTest.java
@@ -209,11 +209,11 @@ public class ITunesParserTest extends AbstractTestCase {
 
         final FeedInformationImpl feedInfo = (FeedInformationImpl) syndfeed.getModule(AbstractITunesObject.URI);
 
-        assertEquals(URI.create("file://some-location/1.jpg"), feedInfo.getImageUri());
+        assertEquals("file://some-location/1.jpg", feedInfo.getImageUri());
 
         SyndEntry entry = syndfeed.getEntries().get(0);
         EntryInformationImpl module = (EntryInformationImpl) entry.getModule(AbstractITunesObject.URI);
 
-        assertEquals(URI.create("gs://some-location/2.jpg"), module.getImageUri());
+        assertEquals("gs://some-location/whitespaces are allowed/2.jpg", module.getImageUri());
     }
 }

--- a/rome-modules/src/test/resources/itunes/no-http-uris.xml
+++ b/rome-modules/src/test/resources/itunes/no-http-uris.xml
@@ -25,7 +25,7 @@
       <title>le Show</title>
       <itunes:author>Harry Shearer</itunes:author>
       <description></description>
-      <itunes:image rel="image" href="gs://some-location/2.jpg"></itunes:image>
+      <itunes:image rel="image" href="gs://some-location/whitespaces are allowed/2.jpg"></itunes:image>
       <enclosure url="http://a1.phobos.apple.com/Podcasts/y2005/m08/d01/h14/eosmhmit.mp3" length="16770270" type="" />
       <guid>http://66.186.18.80/podcast/mp3/ls/ls050731le_Show.mp3</guid>
       <pubDate>Sun, 31 Jul 2005 16:00:00 GMT</pubDate>


### PR DESCRIPTION
This is a followup PR for https://github.com/rometools/rome/pull/445

Unfortunately some links does not follow URI standards, including GCS links. For example this is a valid link in Google Storage `gs://some-location/whitespaces are allowed/2.jpg`, but it is invalid URI because it has whitespaces.

To support non valid URI usecase lets loosen imageUri field type from `URI` to `String`.