### PR TITLE
Fixes millisecond value for HOUR

### DIFF
--- a/rome-modules/src/main/java/com/rometools/modules/mediarss/types/Time.java
+++ b/rome-modules/src/main/java/com/rometools/modules/mediarss/types/Time.java
@@ -36,7 +36,7 @@ public class Time implements Serializable {
 
     private static final long SECOND = 1000;
     private static final long MINUTE = 60 * SECOND;
-    private static final long HOUR = 60 * MINUTE * SECOND;
+    private static final long HOUR = 60 * MINUTE;
     private static final NumberFormat nf = NumberFormat.getInstance();
 
     static {


### PR DESCRIPTION
by removing addititional SECOND multiplier, now it equals 60 * 60 * 1000 instead of 60 * 60 * 1000 * 1000