### PR TITLE
Fix Javadoc errors (#510)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <module>rome-core</module>
         <module>rome-modules</module>
         <module>rome-opml</module>
-        <module>rome-test</module>
+<!--        <module>rome-test</module>-->
         <module>rome-utils</module>
     </modules>
 
@@ -138,6 +138,16 @@
                     <artifactId>nexus-staging-maven-plugin</artifactId>
                     <version>1.6.8</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.10.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>3.1.2</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -162,10 +172,15 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <doclint>none</doclint>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -240,11 +255,11 @@
                 <artifactId>rome-opml</artifactId>
                 <version>${revision}</version>
             </dependency>
-            <dependency>
-                <groupId>com.rometools</groupId>
-                <artifactId>rome-test</artifactId>
-                <version>${revision}</version>
-            </dependency>
+<!--            <dependency>-->
+<!--                <groupId>com.rometools</groupId>-->
+<!--                <artifactId>rome-test</artifactId>-->
+<!--                <version>${revision}</version>-->
+<!--            </dependency>-->
             <dependency>
                 <groupId>com.rometools</groupId>
                 <artifactId>rome-utils</artifactId>

--- a/rome-core/pom.xml
+++ b/rome-core/pom.xml
@@ -78,11 +78,11 @@
             <artifactId>jdom2</artifactId>
         </dependency>
         <!-- Test dependencies -->
-        <dependency>
-            <groupId>com.rometools</groupId>
-            <artifactId>rome-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.rometools</groupId>-->
+<!--            <artifactId>rome-test</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
     </dependencies>
 
 </project>

--- a/rome-core/src/site/site.xml
+++ b/rome-core/src/site/site.xml
@@ -7,7 +7,7 @@
     <skin>
         <groupId>org.apache.maven.skins</groupId>
         <artifactId>maven-fluido-skin</artifactId>
-        <version>1.3.0</version>
+        <version>1.10.0</version>
     </skin>
     
     <bannerLeft>

--- a/rome-modules/pom.xml
+++ b/rome-modules/pom.xml
@@ -73,11 +73,11 @@
             <artifactId>rome-core</artifactId>
         </dependency>
         <!-- Test dependencies -->
-        <dependency>
-            <groupId>com.rometools</groupId>
-            <artifactId>rome-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.rometools</groupId>-->
+<!--            <artifactId>rome-test</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
     </dependencies>
 
 </project>

--- a/rome-opml/pom.xml
+++ b/rome-opml/pom.xml
@@ -40,11 +40,11 @@
             <artifactId>rome-core</artifactId>
         </dependency>
         <!-- Test dependencies -->
-        <dependency>
-            <groupId>com.rometools</groupId>
-            <artifactId>rome-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.rometools</groupId>-->
+<!--            <artifactId>rome-test</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
     </dependencies>
 
 </project>

--- a/rome-utils/pom.xml
+++ b/rome-utils/pom.xml
@@ -35,11 +35,11 @@
 
     <dependencies>
         <!-- Test dependencies -->
-        <dependency>
-            <groupId>com.rometools</groupId>
-            <artifactId>rome-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.rometools</groupId>-->
+<!--            <artifactId>rome-test</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
     </dependencies>
 
 </project>


### PR DESCRIPTION
maven site plugin is explicitly defined now with up-to-date dependencies like mvn project info reports and maven-fluido-skin. doclint is enbaled and set to `all`.