### PR TITLE
Support self links

### DIFF
--- a/rome-core/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom10.java
+++ b/rome-core/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom10.java
@@ -113,9 +113,12 @@ public class ConverterForAtom10 implements Converter {
             syndFeed.setDescriptionEx(c);
         }
 
-        // use first alternate links as THE link
+        // Set the first "self" link as LINK
+        syndFeed.setLink(aFeed.getOtherLinks().stream().filter(l -> "self".equals(l.getRel())).findFirst().map(Link::getHrefResolved).orElse(null));
+
+        // otherwise, use first alternate links as THE link
         final List<Link> alternateLinks = aFeed.getAlternateLinks();
-        if (Lists.isNotEmpty(alternateLinks)) {
+        if (Lists.isNotEmpty(alternateLinks) && syndFeed.getLink() == null) {
             final Link theLink = alternateLinks.get(0);
             syndFeed.setLink(theLink.getHrefResolved());
         }

--- a/rome-core/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom10.java
+++ b/rome-core/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom10.java
@@ -116,7 +116,7 @@ public class ConverterForAtom10 implements Converter {
         // Set the first "self" link as LINK
         syndFeed.setLink(aFeed.getOtherLinks().stream().filter(l -> "self".equals(l.getRel())).findFirst().map(Link::getHrefResolved).orElse(null));
 
-        // otherwise, use first alternate links as THE link
+        // otherwise, use first alternate link as THE link
         final List<Link> alternateLinks = aFeed.getAlternateLinks();
         if (Lists.isNotEmpty(alternateLinks) && syndFeed.getLink() == null) {
             final Link theLink = alternateLinks.get(0);


### PR DESCRIPTION
It appears as if `com.rometools.rome.feed.synd.impl.ConverterForAtom10.copyInto()` only considered `alternate` links and no `self` links.

https://datatracker.ietf.org/doc/html/rfc4287#section-4.1.1 appears to suggest that a `<link rel="self" />` tag should always be considered as the authoritative link.

> atom:feed elements SHOULD contain one atom:link element with a rel attribute value of "self".  This is the preferred URI for retrieving Atom Feed Documents representing this Atom feed.