### PR TITLE
Fixed test case causing by a bug using german locale

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Java
-        uses: actions/setup-java@v3.1.1
+        uses: actions/setup-java@v3.2.0
         with:
           distribution: liberica
           java-version: 11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Java
-        uses: actions/setup-java@v3.1.1
+        uses: actions/setup-java@v3.2.0
         with:
           distribution: liberica
           java-version: 11

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>5.1.4</version>
+                    <version>5.1.5</version>
                     <executions>
                         <execution>
                             <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.3.2</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.22</version>
+                <version>1.18.24</version>
             </dependency>
             <!-- SLF4J -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.12</version>
+                    <version>1.6.13</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/rome-core/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
+++ b/rome-core/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
@@ -37,7 +37,7 @@ public class DateParserTest {
     	
     	assertEquals(
                 c.getTime(),
-                DateParser.parseRFC822("Sa., 28 Mär 20 09:12:38 MEZ", Locale.GERMANY)
+                DateParser.parseRFC822("Sa., 28 März 20 09:12:38 MEZ", Locale.GERMANY)
         );
     }
 }


### PR DESCRIPTION
Hi, @PatrickGotthard:

Until Java9+, German locale has suffered changes that invalidates DateParserTest test cases. This commit fixes bug generated by Java updates. Actually Rome uses Java 11.0.15 in Actions.

Regards!!