### PR TITLE
Remove deprecated modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ Rome is a Java framework for RSS and Atom feeds. The framework consist of severa
 | `rome` | Library for generating and parsing RSS and Atom feeds. |
 | `rome-modules` | Generators and parsers for extensions like MediaRSS, GeoRSS and others. |
 | `rome-opml` | [OPML](https://en.wikipedia.org/wiki/OPML) parsers and tools. |
-| `rome-fetcher` | DEPRECATED (see [#276](https://github.com/rometools/rome/issues/276) for details) |
-
-Other deprecated modules: `rome-certiorem`, `rome-certiorem-webapp` and `rome-propono`.
+| `rome-utils` | Internal utility classes. |
 
 ## Examples
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,8 @@
 
     <modules>
         <module>rome</module>
-        <module>rome-certiorem</module>
-        <module>rome-certiorem-webapp</module>
-        <module>rome-fetcher</module>
         <module>rome-modules</module>
         <module>rome-opml</module>
-        <module>rome-propono</module>
         <module>rome-utils</module>
     </modules>
 


### PR DESCRIPTION
The following deprecated modules will be removed:
- rome-certiorem
- rome-certiorem-webapp
- rome-fetcher
- rome-propono