### PR TITLE
Support parsing of URLs with spaces

### DIFF
--- a/rome-modules/src/main/java/com/rometools/modules/mediarss/io/MediaModuleParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/mediarss/io/MediaModuleParser.java
@@ -76,6 +76,7 @@ import com.rometools.utils.Doubles;
 import com.rometools.utils.Integers;
 import com.rometools.utils.Longs;
 import com.rometools.utils.Strings;
+import com.rometools.utils.URIs;
 
 /**
  * @author Nathanial X. Freitas
@@ -162,7 +163,7 @@ public class MediaModuleParser implements ModuleParser {
 
                 if (content.getAttributeValue("url") != null) {
                     try {
-                        mc = new MediaContent(new UrlReference(new URI(content.getAttributeValue("url").replace(' ', '+'))));
+                        mc = new MediaContent(new UrlReference(URIs.parse(content.getAttributeValue("url"))));
                         mc.setPlayer(parsePlayer(content));
                     } catch (final Exception ex) {
                         LOG.warn("Exception parsing content tag.", ex);

--- a/rome-modules/src/test/java/com/rometools/modules/mediarss/MediaModuleTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/mediarss/MediaModuleTest.java
@@ -188,7 +188,7 @@ public class MediaModuleTest extends AbstractTestCase {
         assertNotNull("missing media:content", mediaContents);
         assertEquals("wrong count of media:content", 1, mediaContents.length);
         final MediaContent mediaContent = mediaContents[0];
-        assertEquals("http://www.foo.com/path/containing+spaces/trailer.mov", mediaContent.getReference().toString());
+        assertEquals("http://www.foo.com/path/containing%20spaces/trailer.mov", mediaContent.getReference().toString());
     }
 
     /**

--- a/rome-utils/pom.xml
+++ b/rome-utils/pom.xml
@@ -33,6 +33,11 @@
             <artifactId>hamcrest-library</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/rome-utils/src/main/java/com/rometools/utils/URIs.java
+++ b/rome-utils/src/main/java/com/rometools/utils/URIs.java
@@ -1,0 +1,33 @@
+package com.rometools.utils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public final class URIs {
+
+    private static final Map<String, String> FIXES = new HashMap<>();
+
+    static {
+        FIXES.put(" ", "%20"); // fix spaces
+    }
+    
+    private URIs() {
+    }
+
+    public static URI parse(final String str) throws URISyntaxException {
+
+        String fixed = str;
+        for (final Entry<String, String> entry : FIXES.entrySet()) {
+            final String search = entry.getKey();
+            final String replace = entry.getValue();
+            fixed = fixed.replace(search, replace);
+        }
+
+        return new URI(fixed);
+
+    }
+
+}

--- a/rome-utils/src/test/java/com/rometools/utils/URIsTest.java
+++ b/rome-utils/src/test/java/com/rometools/utils/URIsTest.java
@@ -1,0 +1,16 @@
+package com.rometools.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URISyntaxException;
+
+import org.junit.Test;
+
+public class URIsTest {
+
+    @Test
+    public void testParse() throws URISyntaxException {
+        assertThat(URIs.parse("https://example.com/test 123.png").toString()).isEqualTo("https://example.com/test%20123.png");
+    }
+
+}


### PR DESCRIPTION
This change adds a utility class for parsing and correcting common URI problems and fixes the current space replacement in MediaModuleParser.

Closes #302