### PR TITLE
Prevent OPML20Generator from creating empty <docs /> element

### DIFF
--- a/rome-opml/src/main/java/com/rometools/opml/io/impl/OPML20Generator.java
+++ b/rome-opml/src/main/java/com/rometools/opml/io/impl/OPML20Generator.java
@@ -68,11 +68,14 @@ public class OPML20Generator extends OPML10Generator {
     @Override
     protected Element generateHead(final Opml opml) {
 
-        final Element docsElement = new Element("docs");
-        docsElement.setText(opml.getDocs());
-
         final Element headElement = super.generateHead(opml);
-        headElement.addContent(docsElement);
+
+        if (headElement != null && opml.getDocs() != null) {
+            final Element docsElement = new Element("docs");
+            docsElement.setText(opml.getDocs());
+            headElement.addContent(docsElement);
+        }
+
         return headElement;
 
     }


### PR DESCRIPTION
Closes #551 and #581 