### PR TITLE
Allow zero lengths for enclosures

### DIFF
--- a/rome/src/main/java/com/rometools/rome/io/impl/RSS092Generator.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/RSS092Generator.java
@@ -142,9 +142,7 @@ public class RSS092Generator extends RSS091UserlandGenerator {
         }
 
         final long length = enclosure.getLength();
-        if (length != 0) {
-            enclosureElement.setAttribute("length", String.valueOf(length));
-        }
+        enclosureElement.setAttribute("length", String.valueOf(length));
 
         final String type = enclosure.getType();
         if (type != null) {


### PR DESCRIPTION
According to the RSS spec the length attribute of the enclosure element is mandatory and should be set to 0 when the length is unknown.
Unfortunately to RSS092Generator removes the length attribute when the value is 0.
This change fixes that.