### PR TITLE
GH-599: Add support for GraalVM native images

### DIFF
--- a/rome/src/main/java/com/rometools/rome/feed/impl/CopyFromHelper.java
+++ b/rome/src/main/java/com/rometools/rome/feed/impl/CopyFromHelper.java
@@ -29,14 +29,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.rometools.rome.feed.CopyFrom;
 
 public class CopyFromHelper {
-
-    private static final Logger LOG = LoggerFactory.getLogger(CopyFromHelper.class);
 
     private static final Set<Class<?>> BASIC_TYPES = new HashSet<Class<?>>();
     private static final Object[] NO_PARAMS = new Object[0];
@@ -93,7 +88,6 @@ public class CopyFromHelper {
             }
 
         } catch (final Exception e) {
-            LOG.error("Error while copying object", e);
             throw new RuntimeException("Could not do a copyFrom " + e, e);
         }
 

--- a/rome/src/main/resources/META-INF/native-image/romtools/reflect-config.json
+++ b/rome/src/main/resources/META-INF/native-image/romtools/reflect-config.json
@@ -1,0 +1,148 @@
+[
+  {
+    "name": "com.rometools.rome.feed.module.DCModuleImpl",
+    "queryAllPublicMethods": true,
+    "allPublicMethods": true,
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.feed.synd.impl.ConverterForAtom03",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.feed.synd.impl.ConverterForAtom10",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.feed.synd.impl.ConverterForRSS090",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.feed.synd.impl.ConverterForRSS091Netscape",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.feed.synd.impl.ConverterForRSS091Userland",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.feed.synd.impl.ConverterForRSS092",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.feed.synd.impl.ConverterForRSS093",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.feed.synd.impl.ConverterForRSS094",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.feed.synd.impl.ConverterForRSS10",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.feed.synd.impl.ConverterForRSS20",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.Atom03Generator",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.Atom03Parser",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.Atom10Generator",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.Atom10Parser",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.DCModuleGenerator",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.DCModuleParser",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS090Generator",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS090Parser",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS091NetscapeGenerator",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS091NetscapeParser",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS091UserlandGenerator",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS091UserlandParser",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS092Generator",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS092Parser",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS093Generator",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS093Parser",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS094Generator",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS094Parser",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS10Generator",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS10Parser",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS20Generator",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS20Parser",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.RSS20wNSParser",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.SyModuleGenerator",
+    "allPublicConstructors":true
+  },
+  {
+    "name": "com.rometools.rome.io.impl.SyModuleParser",
+    "allPublicConstructors":true
+  }
+]

--- a/rome/src/main/resources/META-INF/native-image/romtools/resource-config.json
+++ b/rome/src/main/resources/META-INF/native-image/romtools/resource-config.json
@@ -1,0 +1,15 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qcom/rometools/rome/rome.properties\\E"
+      },
+      {
+        "pattern": "\\Qrome.properties\\E"
+      },
+      {
+        "pattern": "\\Qcom/rometools/modules/base/io/tags.properties\\E"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/rometools/rome/issues/599

There is a lot of reflection in the project which probably has to be reworked this or other way eventually.
But for now it is enough to have a proper reflection info exposed for GraalVM when it builds a native image for our application.

Used a `native-image-agent` to take a required native image config from the running sample application. More info in GraalVM docs: https://www.graalvm.org/22.0/reference-manual/native-image/Agent/. Works only if GraalVM is used to run the application, of course.

In general it is probably better to rework all the content of the `rome.properties` into a Java ServiceLoader API.

There is also too much `clone()` operations with reflection in the project: perhaps better to look into something like deep copy approach.

So, the fix is like this:

* Add `META-INF/native-image/romtools/resource-config.json` to make all the properties from the project available for native image
* Add `META-INF/native-image/romtools/reflect-config.json` for classes in the project used for reflection Mostly content of these files is generated by the mentioned above GraalVM agent
* Remove `LOG` property from the `CopyFromHelper` since it is used only to log an error where we re-throw it immediately anyway. This was an attempt to see if `initialize-at-build-time` for some classes helps us somehow since there is a lot of `static` initialization, but turns out we still do that `clone()` with reflection, so pointless.