### PR TITLE
Downgrade Java from version 11 to 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 8
           cache: maven
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 8
           cache: maven
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     </developers>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <revision>0.0.0-SNAPSHOT</revision>

--- a/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
+++ b/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
@@ -37,7 +37,7 @@ public class DateParserTest {
     	
     	assertEquals(
                 c.getTime(),
-                DateParser.parseRFC822("Sa., 28 März 20 09:12:38 MEZ", Locale.GERMANY)
+                DateParser.parseRFC822("Sa, 28 Mär 20 09:12:38 MEZ", Locale.GERMANY)
         );
     }
 }


### PR DESCRIPTION
Until we rely on features that are only available in newer versions we will stick to Java 8.