### PR TITLE
Adapt CommentAPI namespace, created by Joe Gregorio, creating a new ROME module.

### DIFF
--- a/rome-modules/src/main/java/com/rometools/modules/commentapi/CommentAPI.java
+++ b/rome-modules/src/main/java/com/rometools/modules/commentapi/CommentAPI.java
@@ -1,0 +1,17 @@
+package com.rometools.modules.commentapi;
+
+import com.rometools.rome.feed.module.Module;
+
+public interface CommentAPI extends Module {
+    
+    static final String URI = "http://wellformedweb.org/CommentAPI/";
+
+    String getComment();
+
+    void setComment(final String comment);
+
+    String getCommentRss();
+
+    void setCommentRss(final String commentRss);
+
+}

--- a/rome-modules/src/main/java/com/rometools/modules/commentapi/CommentAPIImpl.java
+++ b/rome-modules/src/main/java/com/rometools/modules/commentapi/CommentAPIImpl.java
@@ -1,0 +1,77 @@
+package com.rometools.modules.commentapi;
+
+import com.rometools.rome.feed.CopyFrom;
+import com.rometools.rome.feed.impl.EqualsBean;
+import com.rometools.rome.feed.impl.ToStringBean;
+import com.rometools.rome.feed.module.ModuleImpl;
+
+public class CommentAPIImpl extends ModuleImpl implements CommentAPI {
+
+    public CommentAPIImpl() {
+        super(CommentAPI.class, CommentAPI.URI);
+    }
+
+    private String comment;
+    private String commentRss;
+
+    @Override
+    public String getComment() {
+        return this.comment;
+    }
+
+    @Override
+    public void setComment(final String comment) {
+        this.comment = comment;
+    }
+
+    @Override
+    public String getCommentRss() {
+        return this.commentRss;
+    }
+
+    @Override
+    public void setCommentRss(final String commentRss) {
+        this.commentRss = commentRss;
+    }
+
+    @Override
+    public String getUri() {
+        return CommentAPI.URI;
+    }
+
+    @Override
+    public Class<? extends CopyFrom> getInterface() {
+        return CommentAPI.class;
+    }
+
+    @Override
+    public Object clone() {
+        final CommentAPIImpl clone = new CommentAPIImpl();
+        clone.setComment(this.getComment());
+        clone.setCommentRss(this.getCommentRss());
+        return clone;
+    }
+
+    @Override
+    public void copyFrom(CopyFrom obj) {
+        final CommentAPI source = (CommentAPI) obj;
+        this.setComment(source.getComment());
+        this.setCommentRss(source.getCommentRss());
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return EqualsBean.beanEquals(CommentAPIImpl.class, this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return EqualsBean.beanHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBean.toString(CommentAPIImpl.class, this);
+    }
+    
+}

--- a/rome-modules/src/main/java/com/rometools/modules/commentapi/io/CommentAPIModuleGenerator.java
+++ b/rome-modules/src/main/java/com/rometools/modules/commentapi/io/CommentAPIModuleGenerator.java
@@ -1,0 +1,59 @@
+package com.rometools.modules.commentapi.io;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+
+import com.rometools.modules.commentapi.CommentAPI;
+import com.rometools.rome.feed.module.Module;
+import com.rometools.rome.io.ModuleGenerator;
+
+public class CommentAPIModuleGenerator implements ModuleGenerator {
+
+    private static final Namespace NS = Namespace.getNamespace("wfw", CommentAPI.URI);
+    private static final Set<Namespace> NAMESPACES = new HashSet<Namespace>();
+
+    static {
+        NAMESPACES.add(NS);
+    }
+
+    public CommentAPIModuleGenerator() {
+        super();
+    }
+
+    @Override
+    public String getNamespaceUri() {
+        return CommentAPI.URI;
+    }
+
+    @Override
+    public Set<Namespace> getNamespaces() {
+        return NAMESPACES;
+    }
+
+    @Override
+    public void generate(Module module, Element element) {
+        if (!(module instanceof CommentAPI)) {
+            return;
+        }
+
+        final CommentAPI commentAPI = (CommentAPI) module;
+
+        if (null != commentAPI.getComment()) {
+            element.addContent(generateSimpleElement("comment", commentAPI.getCommentRss()));
+        }
+
+        if (null != commentAPI.getCommentRss()) {
+            element.addContent(generateSimpleElement("commentRss", commentAPI.getCommentRss()));
+        }
+    }
+    
+    protected Element generateSimpleElement(final String name, final String value) {
+        final Element element = new Element(name, CommentAPIModuleGenerator.NS);
+        element.addContent(value);
+
+        return element;
+    }
+}

--- a/rome-modules/src/main/java/com/rometools/modules/commentapi/io/CommentAPIModuleParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/commentapi/io/CommentAPIModuleParser.java
@@ -1,0 +1,37 @@
+package com.rometools.modules.commentapi.io;
+
+import java.util.Locale;
+
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+
+import com.rometools.modules.commentapi.CommentAPI;
+import com.rometools.modules.commentapi.CommentAPIImpl;
+import com.rometools.rome.feed.module.Module;
+import com.rometools.rome.io.ModuleParser;
+
+public class CommentAPIModuleParser implements ModuleParser {
+    private static final Namespace NS = Namespace.getNamespace(CommentAPI.URI);
+
+    @Override
+    public String getNamespaceUri() {
+        return CommentAPI.URI;
+    }
+
+    @Override
+    public Module parse(Element element, Locale locale) {
+        CommentAPIImpl cai = new CommentAPIImpl();
+
+        Element tag = element.getChild("comment", CommentAPIModuleParser.NS);
+        if (tag != null) {
+            cai.setComment(tag.getText().trim());
+        }
+
+        tag = element.getChild("commentRss", CommentAPIModuleParser.NS);
+        if (tag != null) {
+            cai.setCommentRss(tag.getText().trim());
+        }
+        return cai;
+    }
+    
+}

--- a/rome-modules/src/main/resources/rome.properties
+++ b/rome-modules/src/main/resources/rome.properties
@@ -53,13 +53,15 @@ rss_2.0.item.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS2 \
     com.rometools.modules.mediarss.io.AlternateMediaModuleParser \
     com.rometools.modules.sle.io.ItemParser \
     com.rometools.modules.yahooweather.io.WeatherModuleParser \
-    com.rometools.modules.psc.io.PodloveSimpleChapterParser
+    com.rometools.modules.psc.io.PodloveSimpleChapterParser \
+    com.rometools.modules.commentapi.io.CommentAPIModuleParser
 
 rss_1.0.item.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS1 \
     com.rometools.modules.base.io.GoogleBaseParser \
     com.rometools.modules.base.io.CustomTagParser \
     com.rometools.modules.content.io.ContentModuleParser \
-    com.rometools.modules.slash.io.SlashModuleParser
+    com.rometools.modules.slash.io.SlashModuleParser \
+    com.rometools.modules.commentapi.io.CommentAPIModuleParser
 
 atom_0.3.item.ModuleParser.classes=com.rometools.modules.cc.io.ModuleParserRSS2 \
     com.rometools.modules.base.io.GoogleBaseParser \
@@ -130,7 +132,8 @@ rss_2.0.item.ModuleGenerator.classes=com.rometools.modules.cc.io.CCModuleGenerat
     com.rometools.modules.mediarss.io.MediaModuleGenerator \
     com.rometools.modules.atom.io.AtomModuleGenerator \
     com.rometools.modules.yahooweather.io.WeatherModuleGenerator \
-    com.rometools.modules.psc.io.PodloveSimpleChapterGenerator
+    com.rometools.modules.psc.io.PodloveSimpleChapterGenerator \
+    com.rometools.modules.commentapi.io.CommentAPIModuleGenerator
 
 rss_1.0.item.ModuleGenerator.classes=com.rometools.modules.base.io.GoogleBaseGenerator \
     com.rometools.modules.content.io.ContentModuleGenerator \

--- a/rome-modules/src/test/java/com/rometools/modules/commentapi/CommentAPIGeneratorTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/commentapi/CommentAPIGeneratorTest.java
@@ -1,0 +1,45 @@
+package com.rometools.modules.commentapi;
+
+import java.io.File;
+import java.io.StringWriter;
+
+import com.rometools.modules.AbstractTestCase;
+import com.rometools.modules.commentapi.io.CommentAPIModuleGenerator;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.SyndFeedInput;
+import com.rometools.rome.io.SyndFeedOutput;
+import com.rometools.rome.io.XmlReader;
+
+import junit.framework.TestSuite;
+
+public class CommentAPIGeneratorTest extends AbstractTestCase {
+
+    public CommentAPIGeneratorTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected void setUp() {
+    }
+
+    @Override
+    protected void tearDown() {
+    }
+
+    public static junit.framework.Test suite() {
+        return new TestSuite(CommentAPIGeneratorTest.class);
+    }
+
+    public void testGenerateRss() throws Exception {
+        final SyndFeedInput input = new SyndFeedInput();
+        final SyndFeed feed = input.build(new XmlReader(new File(getTestFile("commentapi/rss.xml"))));
+        final SyndFeedOutput output = new SyndFeedOutput();
+        final StringWriter writer = new StringWriter();
+        output.output(feed, writer);
+    }
+
+    public void testGetNamespaceUri() {
+        assertEquals("Namespace", CommentAPI.URI, new CommentAPIModuleGenerator().getNamespaceUri());
+    }
+    
+}

--- a/rome-modules/src/test/java/com/rometools/modules/commentapi/CommentAPIParserTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/commentapi/CommentAPIParserTest.java
@@ -1,0 +1,47 @@
+package com.rometools.modules.commentapi;
+
+import java.io.File;
+import java.util.Iterator;
+import java.util.List;
+
+import com.rometools.modules.AbstractTestCase;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.SyndFeedInput;
+import com.rometools.rome.io.XmlReader;
+
+import junit.framework.TestSuite;
+
+public class CommentAPIParserTest extends AbstractTestCase {
+
+    public CommentAPIParserTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected void setUp() {
+    }
+
+    @Override
+    protected void tearDown() {
+    }
+
+    public static junit.framework.Test suite() {
+        return new TestSuite(CommentAPIParserTest.class);
+    }
+
+    public void testParseRss() throws Exception {
+        final SyndFeedInput input = new SyndFeedInput();
+        final SyndFeed feed = input.build(new XmlReader(new File(getTestFile("commentapi/rss.xml"))));
+        List<SyndEntry> entries = feed.getEntries();
+        int i = 0;
+        for (Iterator<SyndEntry> it = entries.iterator(); it.hasNext(); ++i) {
+            final SyndEntry entry = it.next();
+            final CommentAPI entryInfo = (CommentAPI) entry.getModule(CommentAPI.URI);
+            assertNotNull(entryInfo);
+            assertEquals(String.format("http://www.example.com/feed/rss/5432%d/comments", i), entryInfo.getComment());
+            assertEquals(String.format("http://www.example.com/feed/rss/5432%d/commentsRss", i), entryInfo.getCommentRss());
+        }
+    }
+
+}

--- a/rome-modules/src/test/resources/commentapi/rss.xml
+++ b/rome-modules/src/test/resources/commentapi/rss.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:wfw="http://wellformedweb.org/CommentAPI/">
+    <channel>
+		<title>Example</title>
+		<description>An RSS Example with WFW</description>
+		<lastBuildDate>Sun, 15 May 2005 13:02:08 -0500</lastBuildDate>
+		<link>http://www.example.com</link>
+		<item>
+			<title>I like Root Beer</title>
+			<guid>d77d2e80-0487-4e8c-a35d-a93f12a0ff7d:article:54320</guid>
+			<pubDate>Sun, 15 May 2005 13:02:08 -0500</pubDate>
+			<link>http://www.example.com/article/54320</link>
+			<wfw:comment>http://www.example.com/feed/rss/54320/comments</wfw:comment>
+			<wfw:commentRss>http://www.example.com/feed/rss/54320/commentsRss</wfw:commentRss>
+		</item>
+		<item>
+			<title>Rain is Wet</title>
+			<guid>d77d2e80-0487-4e8c-a35d-a93f12a0ff7d:article:54321</guid>
+			<pubDate>Sun, 15 May 2005 10:55:12 -0500</pubDate>
+			<link>http://www.example.com/article/54321</link>
+			<wfw:comment>http://www.example.com/feed/rss/54321/comments</wfw:comment>
+			<wfw:commentRss>http://www.example.com/feed/rss/54321/commentsRss</wfw:commentRss>
+		</item>
+		<item>
+			<title>Huh?!</title>
+			<guid>d77d2e80-0487-4e8c-a35d-a93f12a0ff7d:article:54322</guid>
+			<pubDate>Sun, 15 May 2005 08:14:11 -0500</pubDate>
+			<link>http://www.example.com/article/54322</link>
+			<wfw:comment>http://www.example.com/feed/rss/54322/comments</wfw:comment>
+			<wfw:commentRss>http://www.example.com/feed/rss/54322/commentsRss</wfw:commentRss>
+		</item>
+	</channel>
+</rss>


### PR DESCRIPTION
Hi, @PatrickGotthard 

Working on a new patch in eclipse-ee4j/jaxb-ri, I've found this link about mailing dev list, using a different namespace for comments:

https://dev.eclipse.org/mhonarc/lists/jaxb-impl-dev/maillist.rss

It declares a new namespace in RSS header (xmlns:wfw="http://wellformedweb.org/CommentAPI/"), although they are not using these tags in feed. I think that this namespace was pretty popular at past, and now is a good chance to include a new feature in 2.X branch.

Reference links:
https://www.intertwingly.net/wiki/pie/CommentApi
http://web.archive.org/web/20121031233625/http://bitworking.org/news/2012/08/wfw.html

Regards,
Antonio.