### PR TITLE
Update Date to LocalDateTime and related time classes.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4
 
       - name: Setup Java
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v4
         with:
-          distribution: temurin
-          java-version: 8
+          distribution: 'temurin'
+          java-version: '11'
           cache: maven
 
       - name: Build

--- a/rome-modules/src/main/java/com/rometools/modules/sle/io/ItemParser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/sle/io/ItemParser.java
@@ -18,8 +18,8 @@
 package com.rometools.modules.sle.io;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -109,7 +109,7 @@ public class ItemParser implements com.rometools.rome.io.ModuleParser {
                 } else {
                     value.setNamespace(element.getDocument().getRootElement().getNamespace());
                 }
-                Date dateValue = null;
+                LocalDateTime dateValue = null;
 
                 try {
                     dateValue = DateParser.parseRFC822(sort.getAttributeValue("value"), locale);

--- a/rome-modules/src/main/java/com/rometools/modules/sle/types/DateValue.java
+++ b/rome-modules/src/main/java/com/rometools/modules/sle/types/DateValue.java
@@ -17,11 +17,11 @@
  */
 package com.rometools.modules.sle.types;
 
-import java.util.Date;
-
 import org.jdom2.Namespace;
 
 import com.rometools.rome.feed.impl.EqualsBean;
+
+import java.time.LocalDateTime;
 
 /**
  * An EntryValue implementation representing a "date" data-type.
@@ -32,7 +32,7 @@ public class DateValue implements EntryValue {
 
     private String element;
     private String label;
-    private Date value;
+    private LocalDateTime value;
     private Namespace namespace = Namespace.XML_NAMESPACE;
 
     public void setElement(final String element) {
@@ -53,12 +53,12 @@ public class DateValue implements EntryValue {
         return label;
     }
 
-    public void setValue(final Date value) {
+    public void setValue(final LocalDateTime value) {
         this.value = value;
     }
 
     @Override
-    public Date getValue() {
+    public LocalDateTime getValue() {
         return value;
     }
 
@@ -99,8 +99,8 @@ public class DateValue implements EntryValue {
     @Override
     public int compareTo(final EntryValue other) {
         final Comparable<?> otherValue = other.getValue();
-        if (otherValue instanceof Date) {
-            return value.compareTo((Date) otherValue);
+        if (otherValue instanceof LocalDateTime) {
+            return value.compareTo((LocalDateTime) otherValue);
         } else {
             throw new RuntimeException("Can't compare different EntryValue types");
         }

--- a/rome-modules/src/main/java/com/rometools/modules/sse/SSE091Generator.java
+++ b/rome-modules/src/main/java/com/rometools/modules/sse/SSE091Generator.java
@@ -15,7 +15,7 @@
 
 package com.rometools.modules.sse;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -186,8 +186,8 @@ public class SSE091Generator implements DelegatingModuleGenerator {
 
     private String toString(final Object o) {
         if (o != null) {
-            if (o instanceof Date) {
-                return DateParser.formatRFC822((Date) o, Locale.US);
+            if (o instanceof LocalDateTime) {
+                return DateParser.formatRFC822((LocalDateTime) o, Locale.US);
             } else {
                 return o.toString();
             }

--- a/rome-modules/src/main/java/com/rometools/modules/sse/SSE091Parser.java
+++ b/rome-modules/src/main/java/com/rometools/modules/sse/SSE091Parser.java
@@ -15,8 +15,8 @@
 
 package com.rometools.modules.sse;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -229,9 +229,9 @@ public class SSE091Parser implements DelegatingModuleParser {
         return attrValue;
     }
 
-    private Date parseDateAttribute(final Element childElement, final String attrName, final Locale locale) {
+    private LocalDateTime parseDateAttribute(final Element childElement, final String attrName, final Locale locale) {
         final Attribute dateAttribute = childElement.getAttribute(attrName);
-        final Date date = null;
+        final LocalDateTime date = null;
         if (dateAttribute != null) {
             // SSE spec requires the timezone to be 'GMT'
             // admittedly, this is a bit heavy-handed

--- a/rome-modules/src/main/java/com/rometools/modules/sse/modules/Conflict.java
+++ b/rome-modules/src/main/java/com/rometools/modules/sse/modules/Conflict.java
@@ -12,13 +12,13 @@
 
 package com.rometools.modules.sse.modules;
 
-import java.util.Date;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.rometools.rome.feed.CopyFrom;
 import com.rometools.rome.feed.rss.Item;
+
+import java.time.LocalDateTime;
 
 /**
  * <sx:conflict> element within <sx:conflicts>
@@ -57,14 +57,14 @@ public class Conflict extends SSEModule {
     public static final String WHEN_ATTRIBUTE = "when";
 
     private Integer version;
-    private Date when;
+    private LocalDateTime when;
     private String by;
     private Item conflictItem;
 
     @Override
     public void copyFrom(final CopyFrom obj) {
         final Conflict conflict = (Conflict) obj;
-        conflict.when = when == null ? null : (Date) when.clone();
+        conflict.when = when == null ? null : when;
         conflict.by = by;
         conflict.version = version;
         try {
@@ -91,11 +91,11 @@ public class Conflict extends SSEModule {
         this.version = version;
     }
 
-    public Date getWhen() {
+    public LocalDateTime getWhen() {
         return when;
     }
 
-    public void setWhen(final Date when) {
+    public void setWhen(final LocalDateTime when) {
         this.when = when;
     }
 

--- a/rome-modules/src/main/java/com/rometools/modules/sse/modules/History.java
+++ b/rome-modules/src/main/java/com/rometools/modules/sse/modules/History.java
@@ -14,8 +14,8 @@
  */
 package com.rometools.modules.sse.modules;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import com.rometools.rome.feed.CopyFrom;
@@ -37,7 +37,7 @@ public class History extends SSEModule {
     private static final long serialVersionUID = 1L;
 
     // A date-time attribute.
-    private Date when;
+    private LocalDateTime when;
 
     // A string attribute.
     private String by;
@@ -55,7 +55,7 @@ public class History extends SSEModule {
     @Override
     public void copyFrom(final CopyFrom other) {
         final History otherHistory = (History) other;
-        when = otherHistory.when == null ? null : (Date) otherHistory.when.clone();
+        when = otherHistory.when == null ? null : (LocalDateTime) otherHistory.when;
         // dont copy immutable
         by = otherHistory.by;
 
@@ -73,7 +73,7 @@ public class History extends SSEModule {
      *
      * @return the date-time when the most recent modification took place.
      */
-    public Date getWhen() {
+    public LocalDateTime getWhen() {
         // TODO: convert to the earliest time in RFC 822 (which is what?)
         return when;
     }
@@ -85,7 +85,7 @@ public class History extends SSEModule {
      *
      * @param when the date-time when the most recent modification took place.
      */
-    public void setWhen(final Date when) {
+    public void setWhen(final LocalDateTime when) {
         this.when = when;
     }
 

--- a/rome-modules/src/main/java/com/rometools/modules/sse/modules/Related.java
+++ b/rome-modules/src/main/java/com/rometools/modules/sse/modules/Related.java
@@ -14,9 +14,9 @@
  */
 package com.rometools.modules.sse.modules;
 
-import java.util.Date;
-
 import com.rometools.rome.feed.CopyFrom;
+
+import java.time.LocalDateTime;
 
 /**
  * <pre>
@@ -55,9 +55,9 @@ public class Related extends SSEModule {
     // the type of the relation "complete" or "aggregated"
     private Integer type;
     // starting point of the related feed
-    private Date since;
+    private LocalDateTime since;
     // ending point of a feed
-    private Date until;
+    private LocalDateTime until;
 
     public static final String LINK_ATTRIBUTE = "link";
     public static final String SINCE_ATTRIBUTE = "since";
@@ -69,10 +69,10 @@ public class Related extends SSEModule {
     public void copyFrom(final CopyFrom obj) {
         final Related related = (Related) obj;
         related.link = link;
-        related.since = since == null ? null : (Date) since.clone();
+        related.since = since == null ? null : since;
         related.title = title;
         related.type = type;
-        related.until = until == null ? null : (Date) until.clone();
+        related.until = until == null ? null : until;
     }
 
     /**
@@ -142,7 +142,7 @@ public class Related extends SSEModule {
      *
      * @return the starting point of the related feed.
      */
-    public Date getSince() {
+    public LocalDateTime getSince() {
         return since;
     }
 
@@ -151,7 +151,7 @@ public class Related extends SSEModule {
      *
      * @param since the starting point of the related feed.
      */
-    public void setSince(final Date since) {
+    public void setSince(final LocalDateTime since) {
         this.since = since;
     }
 
@@ -160,7 +160,7 @@ public class Related extends SSEModule {
      *
      * @return the ending point of the feed, until.
      */
-    public Date getUntil() {
+    public LocalDateTime getUntil() {
         return until;
     }
 
@@ -169,7 +169,7 @@ public class Related extends SSEModule {
      *
      * @param until the ending point of the feed.
      */
-    public void setUntil(final Date until) {
+    public void setUntil(final LocalDateTime until) {
         this.until = until;
     }
 }

--- a/rome-modules/src/main/java/com/rometools/modules/sse/modules/Sharing.java
+++ b/rome-modules/src/main/java/com/rometools/modules/sse/modules/Sharing.java
@@ -14,9 +14,9 @@
  */
 package com.rometools.modules.sse.modules;
 
-import java.util.Date;
-
 import com.rometools.rome.feed.CopyFrom;
+
+import java.time.LocalDateTime;
 
 /**
  * <pre>
@@ -55,22 +55,22 @@ public class Sharing extends SSEModule {
     // expresses size of the window of change history kept by the published.
     private Integer window;
     // date after which updated items are included in the feed.
-    private Date since;
+    private LocalDateTime since;
     // date after which updated items are not included in the feed.
 
     // version of the sse in shared channel
     private String version;
 
-    private Date until;
+    private LocalDateTime until;
     private Related related;
 
     @Override
     public void copyFrom(final CopyFrom obj) {
         final Sharing sharing = (Sharing) obj;
         ordered = sharing.ordered;
-        since = sharing.since == null ? null : (Date) sharing.since.clone();
+        since = sharing.since == null ? null : sharing.since;
         window = sharing.window;
-        until = sharing.until == null ? null : (Date) sharing.until.clone();
+        until = sharing.until == null ? null : sharing.until;
         version = sharing.version;
     }
 
@@ -123,7 +123,7 @@ public class Sharing extends SSEModule {
      *
      * @return An optional date-time attribute.
      */
-    public Date getSince() {
+    public LocalDateTime getSince() {
         return since;
     }
 
@@ -133,7 +133,7 @@ public class Sharing extends SSEModule {
      *
      * @param since An optional date-time attribute.
      */
-    public void setSince(final Date since) {
+    public void setSince(final LocalDateTime since) {
         this.since = since;
     }
 
@@ -145,7 +145,7 @@ public class Sharing extends SSEModule {
      *
      * @return the date where items updated after this date are not included in the feed.
      */
-    public Date getUntil() {
+    public LocalDateTime getUntil() {
         return until;
     }
 
@@ -154,7 +154,7 @@ public class Sharing extends SSEModule {
      *
      * @param until the date where items updated after this date are not included in the feed.
      */
-    public void setUntil(final Date until) {
+    public void setUntil(final LocalDateTime until) {
         this.until = until;
     }
 

--- a/rome-modules/src/main/java/com/rometools/modules/sse/modules/Update.java
+++ b/rome-modules/src/main/java/com/rometools/modules/sse/modules/Update.java
@@ -14,9 +14,9 @@
  */
 package com.rometools.modules.sse.modules;
 
-import java.util.Date;
-
 import com.rometools.rome.feed.CopyFrom;
+
+import java.time.LocalDateTime;
 
 /**
  * <pre>
@@ -37,13 +37,13 @@ public class Update extends SSEModule {
     public static final String BY_ATTRIBUTE = "by";
     public static final String WHEN_ATTRIBUTE = "when";
 
-    private Date when;
+    private LocalDateTime when;
     private String by;
 
     @Override
     public void copyFrom(final CopyFrom other) {
         final Update otherUpdate = (Update) other;
-        otherUpdate.when = when == null ? null : (Date) when.clone();
+        otherUpdate.when = when == null ? null : when;
         // dont copy immutable
         otherUpdate.by = by;
     }
@@ -53,7 +53,7 @@ public class Update extends SSEModule {
      * omitted the value defaults to the earliest time representable in RFC 822. Either or both of
      * the when or by attributes MUST be present; it is invalid to have neither.
      */
-    public Date getWhen() {
+    public LocalDateTime getWhen() {
         return when;
     }
 
@@ -62,7 +62,7 @@ public class Update extends SSEModule {
      *
      * @param when the date-time when the modification took place.
      */
-    public void setWhen(final Date when) {
+    public void setWhen(final LocalDateTime when) {
         this.when = when;
     }
 

--- a/rome-modules/src/test/java/com/rometools/modules/georss/GeoRSSModuleTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/georss/GeoRSSModuleTest.java
@@ -27,6 +27,7 @@ import com.rometools.rome.io.SyndFeedOutput;
 import com.rometools.rome.io.XmlReader;
 
 import java.io.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -100,7 +101,7 @@ public class GeoRSSModuleTest extends AbstractTestCase {
         entry = new SyndEntryImpl();
         entry.setTitle("ROME v1.0");
         entry.setLink("http://wiki.java.net/bin/view/Javawsxml/Rome01");
-        entry.setPublishedDate(new Date());
+        entry.setPublishedDate(LocalDateTime.now());
         description = new SyndContentImpl();
         description.setType("text/plain");
         description.setValue("Initial release of ROME");

--- a/rome-modules/src/test/java/com/rometools/modules/sse/SSEParserTest.java
+++ b/rome-modules/src/test/java/com/rometools/modules/sse/SSEParserTest.java
@@ -20,8 +20,8 @@
 package com.rometools.modules.sse;
 
 import java.io.File;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -251,9 +251,9 @@ public class SSEParserTest extends AbstractTestCase {
             final History history = sync.getHistory();
             assertNotNull(history);
 
-            final Date when = history.getWhen();
+            final LocalDateTime when = history.getWhen();
             assertNotNull(when);
-            final Date testDate = DateParser.parseRFC822("Fri, 6 Jan 2006 19:24:09 GMT", Locale.US);
+            final LocalDateTime testDate = DateParser.parseRFC822("Fri, 6 Jan 2006 19:24:09 GMT", Locale.US);
             assertEquals(testDate, when);
         }
 

--- a/rome-modules/src/test/resources/org/rometools/feed/module/mediarss/issue-15.xml
+++ b/rome-modules/src/test/resources/org/rometools/feed/module/mediarss/issue-15.xml
@@ -11,7 +11,7 @@
       <link>http://www.foo.com</link>
       <pubDate>Tue, 28 Aug 2001 00:08:56 GMT</pubDate>
       <guid isPermaLink="false">http://www.foo.com</guid>
-      <dc:date>2001-08-28T00:08:56Z</dc:date>
+      <dc:date>2001-08-28T00:08:56.000Z</dc:date>
       <media:community>
         <media:starRating average="3.5" count="20" min="1" max="10" />
         <media:statistics views="5" favorites="5" />

--- a/rome-opml/src/main/java/com/rometools/opml/feed/opml/Opml.java
+++ b/rome-opml/src/main/java/com/rometools/opml/feed/opml/Opml.java
@@ -17,8 +17,8 @@
  */
 package com.rometools.opml.feed.opml;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import com.rometools.rome.feed.WireFeed;
@@ -31,8 +31,8 @@ public class Opml extends WireFeed {
 
     private static final long serialVersionUID = 1L;
 
-    private Date created;
-    private Date modified;
+    private LocalDateTime created;
+    private LocalDateTime modified;
     private Integer verticalScrollState;
     private Integer windowBottom;
     private Integer windowLeft;
@@ -51,7 +51,7 @@ public class Opml extends WireFeed {
      *
      * @param created date-time, indicating when the document was created.
      */
-    public void setCreated(final Date created) {
+    public void setCreated(final LocalDateTime created) {
         this.created = created;
     }
 
@@ -60,7 +60,7 @@ public class Opml extends WireFeed {
      *
      * @return date-time, indicating when the document was created.
      */
-    public Date getCreated() {
+    public LocalDateTime getCreated() {
         return created;
     }
 
@@ -113,7 +113,7 @@ public class Opml extends WireFeed {
      *
      * @param modified date-time, indicating when the document was last modified.
      */
-    public void setModified(final Date modified) {
+    public void setModified(final LocalDateTime modified) {
         this.modified = modified;
     }
 
@@ -122,7 +122,7 @@ public class Opml extends WireFeed {
      *
      * @return date-time, indicating when the document was last modified.
      */
-    public Date getModified() {
+    public LocalDateTime getModified() {
         return modified;
     }
 

--- a/rome-opml/src/main/java/com/rometools/opml/feed/opml/Outline.java
+++ b/rome-opml/src/main/java/com/rometools/opml/feed/opml/Outline.java
@@ -19,9 +19,9 @@ package com.rometools.opml.feed.opml;
 
 import java.io.Serializable;
 import java.net.URL;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 import com.rometools.rome.feed.impl.EqualsBean;
@@ -35,7 +35,7 @@ public class Outline implements Cloneable, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private Date created;
+    private LocalDateTime created;
     private List<Attribute> attributes;
     private List<String> categories;
     private List<Outline> children;
@@ -196,7 +196,7 @@ public class Outline implements Cloneable, Serializable {
      *
      * @param created date-time that the outline node was created.
      */
-    public void setCreated(final Date created) {
+    public void setCreated(final LocalDateTime created) {
         this.created = created;
     }
 
@@ -205,7 +205,7 @@ public class Outline implements Cloneable, Serializable {
      *
      * @return date-time that the outline node was created.
      */
-    public Date getCreated() {
+    public LocalDateTime getCreated() {
         return created;
     }
 
@@ -326,7 +326,7 @@ public class Outline implements Cloneable, Serializable {
         o.setBreakpoint(isBreakpoint());
         o.setCategories(new ArrayList<String>(getCategories()));
         o.setComment(isComment());
-        o.setCreated(created != null ? (Date) created.clone() : null);
+        o.setCreated(created != null ? created : null);
         o.setModules(new ArrayList<Module>(getModules()));
         o.setText(getText());
         o.setTitle(getTitle());

--- a/rome-utils/src/main/java/com/rometools/utils/Dates.java
+++ b/rome-utils/src/main/java/com/rometools/utils/Dates.java
@@ -14,6 +14,7 @@
 
 package com.rometools.utils;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 public final class Dates {
@@ -27,11 +28,11 @@ public final class Dates {
      * @param d The Date to copy, can be null
      * @return null when the input Date was null, a copy of the Date otherwise
      */
-    public static Date copy(final Date d) {
+    public static LocalDateTime copy(final LocalDateTime d) {
         if (d == null) {
             return null;
         } else {
-            return new Date(d.getTime());
+            return d;
         }
     }
 

--- a/rome-utils/src/test/java/com/rometools/utils/DatesTest.java
+++ b/rome-utils/src/test/java/com/rometools/utils/DatesTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 import org.junit.Test;
@@ -28,11 +29,11 @@ public class DatesTest {
     @Test
     public void testCopy() {
 
-        final Date date = new Date();
-        final Date nullDate = null;
+        final LocalDateTime date = LocalDateTime.now();
+        final LocalDateTime nullDate = null;
 
         assertThat(Dates.copy(date), is(notNullValue()));
-        assertThat(Dates.copy(date).getTime(), is(date.getTime()));
+        assertThat(Dates.copy(date), is(date));
         assertThat(Dates.copy(nullDate), is(nullValue()));
 
     }

--- a/rome/src/main/java/com/rometools/rome/feed/atom/Entry.java
+++ b/rome/src/main/java/com/rometools/rome/feed/atom/Entry.java
@@ -17,6 +17,7 @@
 package com.rometools.rome.feed.atom;
 
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -42,9 +43,9 @@ public class Entry implements Cloneable, Serializable, Extendable {
 
     private Content summary;
     private Content title;
-    private Date created; // Atom 0.3 only
-    private Date published; // AKA issued
-    private Date updated; // AKA modified
+    private LocalDateTime created; // Atom 0.3 only
+    private LocalDateTime published; // AKA issued
+    private LocalDateTime updated; // AKA modified
     private Feed source;
     private List<Link> alternateLinks;
     private List<SyndPerson> authors;
@@ -175,7 +176,7 @@ public class Entry implements Cloneable, Serializable, Extendable {
      *
      * @param created the entry created date, <b>null</b> if none.
      */
-    public void setCreated(final Date created) {
+    public void setCreated(final LocalDateTime created) {
         this.created = Dates.copy(created);
     }
 
@@ -185,7 +186,7 @@ public class Entry implements Cloneable, Serializable, Extendable {
      *
      * @return the entry created date, <b>null</b> if none.
      */
-    public Date getCreated() {
+    public LocalDateTime getCreated() {
         return Dates.copy(created);
     }
 
@@ -234,12 +235,12 @@ public class Entry implements Cloneable, Serializable, Extendable {
     }
 
     /**
-     * Sets the entry issued date (Atom 0.3, maps to {@link #setPublished(java.util.Date)}).
+     * Sets the entry issued date (Atom 0.3, maps to {@link #setPublished(LocalDateTime)}).
      * <p>
      *
      * @param issued the entry issued date, <b>null</b> if none.
      */
-    public void setIssued(final Date issued) {
+    public void setIssued(final LocalDateTime issued) {
         published = Dates.copy(issued);
     }
 
@@ -249,7 +250,7 @@ public class Entry implements Cloneable, Serializable, Extendable {
      *
      * @return the entry issued date, <b>null</b> if none.
      */
-    public Date getIssued() {
+    public LocalDateTime getIssued() {
         return Dates.copy(published);
     }
 
@@ -271,12 +272,12 @@ public class Entry implements Cloneable, Serializable, Extendable {
     }
 
     /**
-     * Sets the entry modified date (Atom 0.3, maps to {@link #setUpdated(java.util.Date)}).
+     * Sets the entry modified date (Atom 0.3, maps to {@link #setUpdated(LocalDateTime)}).
      * <p>
      *
      * @param modified the entry modified date, <b>null</b> if none.
      */
-    public void setModified(final Date modified) {
+    public void setModified(final LocalDateTime modified) {
         updated = Dates.copy(modified);
     }
 
@@ -286,7 +287,7 @@ public class Entry implements Cloneable, Serializable, Extendable {
      *
      * @return the entry modified date, <b>null</b> if none.
      */
-    public Date getModified() {
+    public LocalDateTime getModified() {
         return Dates.copy(updated);
     }
 
@@ -356,7 +357,7 @@ public class Entry implements Cloneable, Serializable, Extendable {
      * @param published The published to set.
      * @since Atom 1.0
      */
-    public void setPublished(final Date published) {
+    public void setPublished(final LocalDateTime published) {
         this.published = Dates.copy(published);
     }
 
@@ -367,7 +368,7 @@ public class Entry implements Cloneable, Serializable, Extendable {
      * @return Returns the published.
      * @since Atom 1.0
      */
-    public Date getPublished() {
+    public LocalDateTime getPublished() {
         return Dates.copy(published);
     }
 
@@ -492,7 +493,7 @@ public class Entry implements Cloneable, Serializable, Extendable {
      * @param updated The updated to set.
      * @since Atom 1.0
      */
-    public void setUpdated(final Date updated) {
+    public void setUpdated(final LocalDateTime updated) {
         this.updated = Dates.copy(updated);
     }
 
@@ -503,7 +504,7 @@ public class Entry implements Cloneable, Serializable, Extendable {
      * @return Returns the updated.
      * @since Atom 1.0
      */
-    public Date getUpdated() {
+    public LocalDateTime getUpdated() {
         return Dates.copy(updated);
     }
 

--- a/rome/src/main/java/com/rometools/rome/feed/atom/Feed.java
+++ b/rome/src/main/java/com/rometools/rome/feed/atom/Feed.java
@@ -16,7 +16,7 @@
  */
 package com.rometools.rome.feed.atom;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.rometools.rome.feed.WireFeed;
@@ -43,7 +43,7 @@ public class Feed extends WireFeed {
     private String rights; // AKA copyright
     private Content subtitle; // AKA tagline
     private Content title;
-    private Date updated; // AKA modified
+    private LocalDateTime updated; // AKA modified
     private List<Link> alternateLinks;
     private List<Link> otherLinks;
     private List<Entry> entries;
@@ -342,7 +342,7 @@ public class Feed extends WireFeed {
      *
      * @return the feed modified date, <b>null</b> if none.
      */
-    public Date getModified() {
+    public LocalDateTime getModified() {
         return updated;
     }
 
@@ -352,7 +352,7 @@ public class Feed extends WireFeed {
      *
      * @param modified the feed modified date to set, <b>null</b> if none.
      */
-    public void setModified(final Date modified) {
+    public void setModified(final LocalDateTime modified) {
         updated = modified;
     }
 
@@ -533,7 +533,7 @@ public class Feed extends WireFeed {
      * @return Returns the updated.
      * @since Atom 1.0
      */
-    public Date getUpdated() {
+    public LocalDateTime getUpdated() {
         return updated;
     }
 
@@ -544,7 +544,7 @@ public class Feed extends WireFeed {
      * @param updated The updated to set.
      * @since Atom 1.0
      */
-    public void setUpdated(final Date updated) {
+    public void setUpdated(final LocalDateTime updated) {
         this.updated = updated;
     }
 

--- a/rome/src/main/java/com/rometools/rome/feed/impl/CloneableBean.java
+++ b/rome/src/main/java/com/rometools/rome/feed/impl/CloneableBean.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -127,6 +128,8 @@ public class CloneableBean {
             } else if (value instanceof Map) {
                 value = (T) cloneMap((Map<Object, Object>) value);
             } else if (isBasicType(vClass)) {
+                // NOTHING SPECIAL TO DO HERE, THEY ARE INMUTABLE
+            } else if (value instanceof LocalDateTime) {
                 // NOTHING SPECIAL TO DO HERE, THEY ARE INMUTABLE
             } else if (value instanceof Cloneable) {
                 final Method cloneMethod = vClass.getMethod("clone", NO_PARAMS_DEF);

--- a/rome/src/main/java/com/rometools/rome/feed/impl/CopyFromHelper.java
+++ b/rome/src/main/java/com/rometools/rome/feed/impl/CopyFromHelper.java
@@ -18,9 +18,9 @@ package com.rometools.rome.feed.impl;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -50,7 +50,7 @@ public class CopyFromHelper {
         BASIC_TYPES.add(Long.class);
         BASIC_TYPES.add(Short.class);
         BASIC_TYPES.add(String.class);
-        BASIC_TYPES.add(Date.class);
+        BASIC_TYPES.add(LocalDateTime.class);
     }
 
     public CopyFromHelper(final Class<? extends CopyFrom> beanInterfaceClass, final Map<String, Class<?>> basePropInterfaceMap,
@@ -113,9 +113,6 @@ public class CopyFromHelper {
                 value = (T) this.<Object, Object> doCopyMap((Map<Object, Object>) value, baseInterface);
             } else if (isBasicType(vClass)) {
                 // value = value; // nothing to do here
-                if (value instanceof Date) { // because Date it is not inmutable
-                    value = (T) ((Date) value).clone();
-                }
             } else { // it goes CopyFrom
                 if (value instanceof CopyFrom) {
                     final CopyFrom source = (CopyFrom) value;

--- a/rome/src/main/java/com/rometools/rome/feed/module/DCModule.java
+++ b/rome/src/main/java/com/rometools/rome/feed/module/DCModule.java
@@ -16,7 +16,7 @@
  */
 package com.rometools.rome.feed.module;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -272,7 +272,7 @@ public interface DCModule extends Module {
      * @return a list of Strings representing the DublinCore module date, an empty list if none.
      *
      */
-    List<Date> getDates();
+    List<LocalDateTime> getDates();
 
     /**
      * Sets the DublinCore module dates.
@@ -282,7 +282,7 @@ public interface DCModule extends Module {
      *            or <b>null</b> if none.
      *
      */
-    void setDates(List<Date> dates);
+    void setDates(List<LocalDateTime> dates);
 
     /**
      * Gets the DublinCore module date. Convenience method that can be used to obtain the first
@@ -291,7 +291,7 @@ public interface DCModule extends Module {
      *
      * @return the first DublinCore module date, <b>null</b> if none.
      */
-    Date getDate();
+    LocalDateTime getDate();
 
     /**
      * Sets the DublinCore module date. Convenience method that can be used when there is only one
@@ -301,7 +301,7 @@ public interface DCModule extends Module {
      * @param date the DublinCore module date to set, <b>null</b> if none.
      *
      */
-    void setDate(Date date);
+    void setDate(LocalDateTime date);
 
     /**
      * Returns the DublinCore module type.

--- a/rome/src/main/java/com/rometools/rome/feed/module/DCModuleImpl.java
+++ b/rome/src/main/java/com/rometools/rome/feed/module/DCModuleImpl.java
@@ -16,8 +16,8 @@
  */
 package com.rometools.rome.feed.module;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -47,7 +47,7 @@ public class DCModuleImpl extends ModuleImpl implements DCModule {
     private List<String> description;
     private List<String> publisher;
     private List<String> contributors;
-    private List<Date> date;
+    private List<LocalDateTime> date;
     private List<String> type;
     private List<String> format;
     private List<String> identifier;
@@ -60,7 +60,7 @@ public class DCModuleImpl extends ModuleImpl implements DCModule {
     /**
      * Properties to be ignored when cloning.
      */
-    private static final Set<String> IGNORE_PROPERTIES = new HashSet<String>();
+    private static final Set<String> IGNORE_PROPERTIES = new HashSet<>();
 
     /**
      * Unmodifiable Set containing the convenience properties of this class.
@@ -404,7 +404,7 @@ public class DCModuleImpl extends ModuleImpl implements DCModule {
      *
      */
     @Override
-    public List<Date> getDates() {
+    public List<LocalDateTime> getDates() {
         return date = Lists.createWhenNull(date);
     }
 
@@ -417,7 +417,7 @@ public class DCModuleImpl extends ModuleImpl implements DCModule {
      *
      */
     @Override
-    public void setDates(final List<Date> dates) {
+    public void setDates(final List<LocalDateTime> dates) {
         date = dates;
     }
 
@@ -429,7 +429,7 @@ public class DCModuleImpl extends ModuleImpl implements DCModule {
      * @return the first DublinCore module date, <b>null</b> if none.
      */
     @Override
-    public Date getDate() {
+    public LocalDateTime getDate() {
         return Lists.firstEntry(date);
     }
 
@@ -442,7 +442,7 @@ public class DCModuleImpl extends ModuleImpl implements DCModule {
      *
      */
     @Override
-    public void setDate(final Date date) {
+    public void setDate(final LocalDateTime date) {
         this.date = Lists.create(date);
     }
 
@@ -865,7 +865,7 @@ public class DCModuleImpl extends ModuleImpl implements DCModule {
      * method.
      * <p>
      *
-     * @param other he reference object with which to compare.
+     * @param other the reference object with which to compare.
      * @return <b>true</b> if 'this' object is equal to the 'other' object.
      *
      */
@@ -920,7 +920,7 @@ public class DCModuleImpl extends ModuleImpl implements DCModule {
         basePropInterfaceMap.put("descriptions", String.class);
         basePropInterfaceMap.put("publishers", String.class);
         basePropInterfaceMap.put("contributors", String.class);
-        basePropInterfaceMap.put("dates", Date.class);
+        basePropInterfaceMap.put("dates", LocalDateTime.class);
         basePropInterfaceMap.put("types", String.class);
         basePropInterfaceMap.put("formats", String.class);
         basePropInterfaceMap.put("identifiers", String.class);

--- a/rome/src/main/java/com/rometools/rome/feed/module/SyModule.java
+++ b/rome/src/main/java/com/rometools/rome/feed/module/SyModule.java
@@ -16,7 +16,8 @@
  */
 package com.rometools.rome.feed.module;
 
-import java.util.Date;
+
+import java.time.LocalDateTime;
 
 /**
  * Syndication ModuleImpl.
@@ -81,7 +82,7 @@ public interface SyModule extends Module {
      * @return the Syndication module update base date, <b>null</b> if none.
      *
      */
-    Date getUpdateBase();
+    LocalDateTime getUpdateBase();
 
     /**
      * Sets the Syndication module update base date.
@@ -90,6 +91,6 @@ public interface SyModule extends Module {
      * @param updateBase the Syndication module update base date to set, <b>null</b> if none.
      *
      */
-    void setUpdateBase(Date updateBase);
+    void setUpdateBase(LocalDateTime updateBase);
 
 }

--- a/rome/src/main/java/com/rometools/rome/feed/module/SyModuleImpl.java
+++ b/rome/src/main/java/com/rometools/rome/feed/module/SyModuleImpl.java
@@ -16,8 +16,8 @@
  */
 package com.rometools.rome.feed.module;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -42,7 +42,7 @@ public class SyModuleImpl extends ModuleImpl implements SyModule {
 
     private String updatePeriod;
     private int updateFrequency;
-    private Date updateBase;
+    private LocalDateTime updateBase;
 
     static {
 
@@ -55,7 +55,7 @@ public class SyModuleImpl extends ModuleImpl implements SyModule {
         final Map<String, Class<?>> basePropInterfaceMap = new HashMap<String, Class<?>>();
         basePropInterfaceMap.put("updatePeriod", String.class);
         basePropInterfaceMap.put("updateFrequency", Integer.TYPE);
-        basePropInterfaceMap.put("updateBase", Date.class);
+        basePropInterfaceMap.put("updateBase", LocalDateTime.class);
         final Map<Class<? extends CopyFrom>, Class<?>> basePropClassImplMap = Collections.<Class<? extends CopyFrom>, Class<?>> emptyMap();
         COPY_FROM_HELPER = new CopyFromHelper(SyModule.class, basePropInterfaceMap, basePropClassImplMap);
 
@@ -124,7 +124,7 @@ public class SyModuleImpl extends ModuleImpl implements SyModule {
      *
      */
     @Override
-    public Date getUpdateBase() {
+    public LocalDateTime getUpdateBase() {
         return Dates.copy(updateBase);
     }
 
@@ -136,7 +136,7 @@ public class SyModuleImpl extends ModuleImpl implements SyModule {
      *
      */
     @Override
-    public void setUpdateBase(final Date updateBase) {
+    public void setUpdateBase(final LocalDateTime updateBase) {
         this.updateBase = Dates.copy(updateBase);
     }
 

--- a/rome/src/main/java/com/rometools/rome/feed/rss/Channel.java
+++ b/rome/src/main/java/com/rometools/rome/feed/rss/Channel.java
@@ -17,6 +17,7 @@
  */
 package com.rometools.rome.feed.rss;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -71,8 +72,8 @@ public class Channel extends WireFeed {
     private String language;
     private String rating;
     private String copyright;
-    private Date pubDate;
-    private Date lastBuildDate;
+    private LocalDateTime pubDate;
+    private LocalDateTime lastBuildDate;
     private String docs;
     private String managingEditor;
     private String webMaster;
@@ -328,7 +329,7 @@ public class Channel extends WireFeed {
      * @return the channel publishing date, <b>null</b> if none.
      *
      */
-    public Date getPubDate() {
+    public LocalDateTime getPubDate() {
         return Dates.copy(pubDate);
     }
 
@@ -339,7 +340,7 @@ public class Channel extends WireFeed {
      * @param pubDate the channel publishing date to set, <b>null</b> if none.
      *
      */
-    public void setPubDate(final Date pubDate) {
+    public void setPubDate(final LocalDateTime pubDate) {
         this.pubDate = Dates.copy(pubDate);
     }
 
@@ -350,7 +351,7 @@ public class Channel extends WireFeed {
      * @return the channel last build date, <b>null</b> if none.
      *
      */
-    public Date getLastBuildDate() {
+    public LocalDateTime getLastBuildDate() {
         return Dates.copy(lastBuildDate);
     }
 
@@ -361,8 +362,8 @@ public class Channel extends WireFeed {
      * @param lastBuildDate the channel last build date to set, <b>null</b> if none.
      *
      */
-    public void setLastBuildDate(final Date lastBuildDate) {
-        this.lastBuildDate = Dates.copy(lastBuildDate);
+    public void setLastBuildDate(final LocalDateTime lastBuildDate) {
+        this.lastBuildDate = lastBuildDate;
     }
 
     /**

--- a/rome/src/main/java/com/rometools/rome/feed/rss/Item.java
+++ b/rome/src/main/java/com/rometools/rome/feed/rss/Item.java
@@ -18,6 +18,7 @@
 package com.rometools.rome.feed.rss;
 
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -56,12 +57,13 @@ public class Item implements Cloneable, Serializable, Extendable {
     private Guid guid;
     private String comments;
     private String author;
-    private Date pubDate;
-    private Date expirationDate;
+    private LocalDateTime pubDate;
+    private LocalDateTime expirationDate;
     private List<Module> modules;
     private List<Element> foreignMarkup;
 
-    public Item() { }
+    public Item() {
+    }
 
     /**
      * Creates a deep 'bean' clone of the object.
@@ -69,7 +71,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      *
      * @return a clone of the object.
      * @throws CloneNotSupportedException thrown if an element of the object cannot be cloned.
-     *
      */
     @Override
     public Object clone() throws CloneNotSupportedException {
@@ -83,7 +84,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      *
      * @param other he reference object with which to compare.
      * @return <b>true</b> if 'this' object is equal to the 'other' object.
-     *
      */
     @Override
     public boolean equals(final Object other) {
@@ -106,7 +106,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return the hashcode of the bean object.
-     *
      */
     @Override
     public int hashCode() {
@@ -118,7 +117,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return String representation for the object.
-     *
      */
     @Override
     public String toString() {
@@ -130,7 +128,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return the item title, <b>null</b> if none.
-     *
      */
     public String getTitle() {
         return title;
@@ -141,7 +138,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @param title the item title to set, <b>null</b> if none.
-     *
      */
     public void setTitle(final String title) {
         this.title = title;
@@ -152,7 +148,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return the item link, <b>null</b> if none.
-     *
      */
     public String getLink() {
         return link;
@@ -163,7 +158,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @param link the item link to set, <b>null</b> if none.
-     *
      */
     public void setLink(final String link) {
         this.link = link;
@@ -194,7 +188,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return the item description, <b>null</b> if none.
-     *
      */
     public Description getDescription() {
         return description;
@@ -205,7 +198,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @param description the item description to set, <b>null</b> if none.
-     *
      */
     public void setDescription(final Description description) {
         this.description = description;
@@ -216,7 +208,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return the item content, <b>null</b> if none.
-     *
      */
     public Content getContent() {
         return content;
@@ -227,7 +218,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @param content the item content to set, <b>null</b> if none.
-     *
      */
     public void setContent(final Content content) {
         this.content = content;
@@ -238,7 +228,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return the item source, <b>null</b> if none.
-     *
      */
     public Source getSource() {
         return source;
@@ -249,7 +238,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @param source the item source to set, <b>null</b> if none.
-     *
      */
     public void setSource(final Source source) {
         this.source = source;
@@ -260,7 +248,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return a list of Enclosure elements with the item enclosures, an empty list if none.
-     *
      */
     public List<Enclosure> getEnclosures() {
         return enclosures = Lists.createWhenNull(enclosures);
@@ -271,8 +258,7 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @param enclosures the list of Enclosure elements with the item enclosures to set, an empty
-     *            list or <b>null</b> if none.
-     *
+     *                   list or <b>null</b> if none.
      */
     public void setEnclosures(final List<Enclosure> enclosures) {
         this.enclosures = enclosures;
@@ -283,7 +269,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return a list of Category elements with the item categories, an empty list if none.
-     *
      */
     public List<Category> getCategories() {
         return categories = Lists.createWhenNull(categories);
@@ -294,8 +279,7 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @param categories the list of Categories elements with the item categories to set, an empty
-     *            list or <b>null</b> if none.
-     *
+     *                   list or <b>null</b> if none.
      */
     public void setCategories(final List<Category> categories) {
         this.categories = categories;
@@ -306,7 +290,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return the item GUID, <b>null</b> if none.
-     *
      */
     public Guid getGuid() {
         return guid;
@@ -317,7 +300,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @param guid the item GUID to set, <b>null</b> if none.
-     *
      */
     public void setGuid(final Guid guid) {
         this.guid = guid;
@@ -328,7 +310,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return the item comments, <b>null</b> if none.
-     *
      */
     public String getComments() {
         return comments;
@@ -339,7 +320,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @param comments the item comments to set, <b>null</b> if none.
-     *
      */
     public void setComments(final String comments) {
         this.comments = comments;
@@ -350,7 +330,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return the item author, <b>null</b> if none.
-     *
      */
     public String getAuthor() {
         return author;
@@ -361,7 +340,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @param author the item author to set, <b>null</b> if none.
-     *
      */
     public void setAuthor(final String author) {
         this.author = author;
@@ -372,7 +350,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return a list of ModuleImpl elements with the item modules, an empty list if none.
-     *
      */
     @Override
     public List<Module> getModules() {
@@ -384,8 +361,7 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @param modules the list of ModuleImpl elements with the item modules to set, an empty list or
-     *            <b>null</b> if none.
-     *
+     *                <b>null</b> if none.
      */
     @Override
     public void setModules(final List<Module> modules) {
@@ -409,10 +385,9 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return the item publishing date, <b>null</b> if none.
-     *
      */
-    public Date getPubDate() {
-        return Dates.copy(pubDate);
+    public LocalDateTime getPubDate() {
+        return pubDate;
     }
 
     /**
@@ -420,10 +395,9 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @param pubDate the item publishing date to set, <b>null</b> if none.
-     *
      */
-    public void setPubDate(final Date pubDate) {
-        this.pubDate = Dates.copy(pubDate);
+    public void setPubDate(final LocalDateTime pubDate) {
+        this.pubDate = pubDate;
     }
 
     /**
@@ -431,10 +405,9 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return the item expiration date, <b>null</b> if none.
-     *
      */
-    public Date getExpirationDate() {
-        return Dates.copy(expirationDate);
+    public LocalDateTime getExpirationDate() {
+        return expirationDate;
     }
 
     /**
@@ -442,10 +415,9 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @param expirationDate the item expiration date to set, <b>null</b> if none.
-     *
      */
-    public void setExpirationDate(final Date expirationDate) {
-        this.expirationDate = Dates.copy(expirationDate);
+    public void setExpirationDate(final LocalDateTime expirationDate) {
+        this.expirationDate = expirationDate;
     }
 
     /**
@@ -453,7 +425,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @return Opaque object to discourage use
-     *
      */
     public List<Element> getForeignMarkup() {
         return foreignMarkup = Lists.createWhenNull(foreignMarkup);
@@ -464,7 +435,6 @@ public class Item implements Cloneable, Serializable, Extendable {
      * <p>
      *
      * @param foreignMarkup Opaque object to discourage use
-     *
      */
     public void setForeignMarkup(final List<Element> foreignMarkup) {
         this.foreignMarkup = foreignMarkup;

--- a/rome/src/main/java/com/rometools/rome/feed/synd/SyndEntry.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/SyndEntry.java
@@ -16,7 +16,7 @@
  */
 package com.rometools.rome.feed.synd;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.jdom2.Element;
@@ -197,7 +197,7 @@ public interface SyndEntry extends Cloneable, CopyFrom, Extendable {
      * @return the entry published date, <b>null</b> if none.
      *
      */
-    Date getPublishedDate();
+    LocalDateTime getPublishedDate();
 
     /**
      * Sets the entry published date.
@@ -208,7 +208,7 @@ public interface SyndEntry extends Cloneable, CopyFrom, Extendable {
      * @param publishedDate the entry published date to set, <b>null</b> if none.
      *
      */
-    void setPublishedDate(Date publishedDate);
+    void setPublishedDate(LocalDateTime publishedDate);
 
     /**
      * Returns the entry updated date.
@@ -217,7 +217,7 @@ public interface SyndEntry extends Cloneable, CopyFrom, Extendable {
      * @return the entry updated date, <b>null</b> if none.
      *
      */
-    Date getUpdatedDate();
+    LocalDateTime getUpdatedDate();
 
     /**
      * Sets the entry updated date.
@@ -226,7 +226,7 @@ public interface SyndEntry extends Cloneable, CopyFrom, Extendable {
      * @param updatedDate the entry updated date to set, <b>null</b> if none.
      *
      */
-    void setUpdatedDate(Date updatedDate);
+    void setUpdatedDate(LocalDateTime updatedDate);
 
     /**
      * Returns the entry authors.

--- a/rome/src/main/java/com/rometools/rome/feed/synd/SyndEntryImpl.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/SyndEntryImpl.java
@@ -17,9 +17,9 @@
 package com.rometools.rome.feed.synd;
 
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -59,7 +59,7 @@ public class SyndEntryImpl implements Serializable, SyndEntry {
     private String uri;
     private String link;
     private String comments;
-    private Date updatedDate;
+    private LocalDateTime updatedDate;
     private SyndContent title;
     private SyndContent description;
     private List<SyndLink> links;
@@ -398,7 +398,7 @@ public class SyndEntryImpl implements Serializable, SyndEntry {
      *
      */
     @Override
-    public Date getPublishedDate() {
+    public LocalDateTime getPublishedDate() {
         return getDCModule().getDate();
     }
 
@@ -412,7 +412,7 @@ public class SyndEntryImpl implements Serializable, SyndEntry {
      *
      */
     @Override
-    public void setPublishedDate(final Date publishedDate) {
+    public void setPublishedDate(final LocalDateTime publishedDate) {
         getDCModule().setDate(publishedDate);
     }
 
@@ -533,7 +533,7 @@ public class SyndEntryImpl implements Serializable, SyndEntry {
      * @return Returns the updatedDate.
      */
     @Override
-    public Date getUpdatedDate() {
+    public LocalDateTime getUpdatedDate() {
         return Dates.copy(updatedDate);
     }
 
@@ -544,8 +544,8 @@ public class SyndEntryImpl implements Serializable, SyndEntry {
      * @param updatedDate The updatedDate to set.
      */
     @Override
-    public void setUpdatedDate(final Date updatedDate) {
-        this.updatedDate = new Date(updatedDate.getTime());
+    public void setUpdatedDate(final LocalDateTime updatedDate) {
+        this.updatedDate = updatedDate;
     }
 
     @Override

--- a/rome/src/main/java/com/rometools/rome/feed/synd/SyndFeed.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/SyndFeed.java
@@ -16,7 +16,7 @@
  */
 package com.rometools.rome.feed.synd;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.jdom2.Element;
@@ -300,7 +300,7 @@ public interface SyndFeed extends Cloneable, CopyFrom, Extendable {
      * @return the feed published date, <b>null</b> if none.
      *
      */
-    Date getPublishedDate();
+    LocalDateTime getPublishedDate();
 
     /**
      * Sets the feed published date.
@@ -311,7 +311,7 @@ public interface SyndFeed extends Cloneable, CopyFrom, Extendable {
      * @param publishedDate the feed published date to set, <b>null</b> if none.
      *
      */
-    void setPublishedDate(Date publishedDate);
+    void setPublishedDate(LocalDateTime publishedDate);
 
     /**
      * Returns the feed authors.

--- a/rome/src/main/java/com/rometools/rome/feed/synd/SyndFeedImpl.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/SyndFeedImpl.java
@@ -17,8 +17,8 @@
 package com.rometools.rome.feed.synd;
 
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -102,7 +102,7 @@ public class SyndFeedImpl implements Serializable, SyndFeed {
         IGNORE_PROPERTIES.add("categories");
         IGNORE_PROPERTIES.add("language");
 
-        final Map<String, Class<?>> basePropInterfaceMap = new HashMap<String, Class<?>>();
+        final Map<String, Class<?>> basePropInterfaceMap = new HashMap<>();
         basePropInterfaceMap.put("feedType", String.class);
         basePropInterfaceMap.put("encoding", String.class);
         basePropInterfaceMap.put("uri", String.class);
@@ -114,7 +114,7 @@ public class SyndFeedImpl implements Serializable, SyndFeed {
         basePropInterfaceMap.put("modules", Module.class);
         basePropInterfaceMap.put("categories", SyndCategory.class);
 
-        final Map<Class<? extends CopyFrom>, Class<?>> basePropClassImplMap = new HashMap<Class<? extends CopyFrom>, Class<?>>();
+        final Map<Class<? extends CopyFrom>, Class<?>> basePropClassImplMap = new HashMap<>();
         basePropClassImplMap.put(SyndEntry.class, SyndEntryImpl.class);
         basePropClassImplMap.put(SyndImage.class, SyndImageImpl.class);
         basePropClassImplMap.put(SyndCategory.class, SyndCategoryImpl.class);
@@ -215,7 +215,7 @@ public class SyndFeedImpl implements Serializable, SyndFeed {
      */
     @Override
     public boolean equals(final Object other) {
-        if (other == null || !(other instanceof SyndFeedImpl)) {
+        if (!(other instanceof SyndFeedImpl)) {
             return false;
         }
         // can't use foreign markup in equals, due to JDOM equals impl
@@ -571,7 +571,7 @@ public class SyndFeedImpl implements Serializable, SyndFeed {
      *
      */
     @Override
-    public Date getPublishedDate() {
+    public LocalDateTime getPublishedDate() {
         return getDCModule().getDate();
     }
 
@@ -585,7 +585,7 @@ public class SyndFeedImpl implements Serializable, SyndFeed {
      *
      */
     @Override
-    public void setPublishedDate(final Date publishedDate) {
+    public void setPublishedDate(final LocalDateTime publishedDate) {
         getDCModule().setDate(publishedDate);
     }
 

--- a/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom03.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom03.java
@@ -17,8 +17,8 @@
  */
 package com.rometools.rome.feed.synd.impl;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import org.jdom2.Element;
@@ -142,7 +142,7 @@ public class ConverterForAtom03 implements Converter {
             syndFeed.setCopyright(copyright);
         }
 
-        final Date date = aFeed.getModified();
+        final LocalDateTime date = aFeed.getModified();
         if (date != null) {
             syndFeed.setPublishedDate(date);
         }
@@ -150,11 +150,10 @@ public class ConverterForAtom03 implements Converter {
     }
 
     protected List<SyndLink> createSyndLinks(final List<Link> atomLinks) {
-        final ArrayList<SyndLink> syndLinks = new ArrayList<SyndLink>();
+        final ArrayList<SyndLink> syndLinks = new ArrayList<>();
         for (final Link atomLink : atomLinks) {
-            final Link link = atomLink;
-            if (!link.getRel().equals("enclosure")) {
-                final SyndLink syndLink = createSyndLink(link);
+            if (!atomLink.getRel().equals("enclosure")) {
+                final SyndLink syndLink = createSyndLink(atomLink);
                 syndLinks.add(syndLink);
             }
         }
@@ -207,9 +206,8 @@ public class ConverterForAtom03 implements Converter {
         final List<Link> otherLinks = entry.getOtherLinks();
         if (Lists.isNotEmpty(otherLinks)) {
             for (final Link otherLink : otherLinks) {
-                final Link thisLink = otherLink;
-                if ("enclosure".equals(thisLink.getRel())) {
-                    syndEnclosures.add(createSyndEnclosure(entry, thisLink));
+                if ("enclosure".equals(otherLink.getRel())) {
+                    syndEnclosures.add(createSyndEnclosure(entry, otherLink));
                 }
             }
         }
@@ -270,7 +268,7 @@ public class ConverterForAtom03 implements Converter {
             syndEntry.setAuthor(firstPerson.getName());
         }
 
-        Date date = entry.getModified();
+        LocalDateTime date = entry.getModified();
         if (date == null) {
             date = Alternatives.firstNotNull(entry.getIssued(), entry.getCreated());
         }
@@ -325,8 +323,7 @@ public class ConverterForAtom03 implements Converter {
         final List<SyndLink> slinks = syndFeed.getLinks();
         if (slinks != null) {
             for (final SyndLink syndLink2 : slinks) {
-                final SyndLink syndLink = syndLink2;
-                final Link link = createAtomLink(syndLink);
+                final Link link = createAtomLink(syndLink2);
                 final String rel = link.getRel();
                 if (Strings.isBlank(rel) || "alternate".equals(rel)) {
                     alternateLinks.add(link);
@@ -380,12 +377,11 @@ public class ConverterForAtom03 implements Converter {
     protected static List<SyndPerson> createAtomPersons(final List<SyndPerson> sPersons) {
         final List<SyndPerson> persons = new ArrayList<SyndPerson>();
         for (final SyndPerson syndPerson : sPersons) {
-            final SyndPerson sPerson = syndPerson;
             final Person person = new Person();
-            person.setName(sPerson.getName());
-            person.setUri(sPerson.getUri());
-            person.setEmail(sPerson.getEmail());
-            person.setModules(sPerson.getModules());
+            person.setName(syndPerson.getName());
+            person.setUri(syndPerson.getUri());
+            person.setEmail(syndPerson.getEmail());
+            person.setModules(syndPerson.getModules());
             persons.add(person);
         }
         return persons;
@@ -436,8 +432,8 @@ public class ConverterForAtom03 implements Converter {
         }
 
         // separate SyndEntry's links collection into alternate and other links
-        final List<Link> alternateLinks = new ArrayList<Link>();
-        final List<Link> otherLinks = new ArrayList<Link>();
+        final List<Link> alternateLinks = new ArrayList<>();
+        final List<Link> otherLinks = new ArrayList<>();
         final List<SyndLink> syndLinks = sEntry.getLinks();
 
         if (syndLinks != null) {

--- a/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom10.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForAtom10.java
@@ -16,8 +16,8 @@
  */
 package com.rometools.rome.feed.synd.impl;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import org.jdom2.Element;
@@ -160,7 +160,7 @@ public class ConverterForAtom10 implements Converter {
             syndFeed.setCopyright(rights);
         }
 
-        final Date date = aFeed.getUpdated();
+        final LocalDateTime date = aFeed.getUpdated();
         if (date != null) {
             syndFeed.setPublishedDate(date);
         }
@@ -227,7 +227,7 @@ public class ConverterForAtom10 implements Converter {
             syndEntry.setContributors(ConverterForAtom03.createSyndPersons(contributors));
         }
 
-        Date date = entry.getPublished();
+        LocalDateTime date = entry.getPublished();
         if (date != null) {
             syndEntry.setPublishedDate(date);
         }

--- a/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForRSS091Userland.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForRSS091Userland.java
@@ -31,8 +31,8 @@ import com.rometools.rome.feed.synd.SyndImage;
 import com.rometools.rome.feed.synd.SyndPerson;
 import com.rometools.utils.Lists;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -66,7 +66,7 @@ public class ConverterForRSS091Userland extends ConverterForRSS090 {
 
         syndFeed.setGenerator(channel.getGenerator());
 
-        final Date pubDate = channel.getPubDate();
+        final LocalDateTime pubDate = channel.getPubDate();
 
         if (pubDate != null) {
             syndFeed.setPublishedDate(pubDate); // c
@@ -82,8 +82,7 @@ public class ConverterForRSS091Userland extends ConverterForRSS090 {
 
             if (!creators.contains(author)) {
                 // using a set to remove duplicates
-                final Set<String> s = new LinkedHashSet<String>();
-                s.addAll(creators); // DC creators
+                final Set<String> s = new LinkedHashSet<>(creators); // DC creators
                 s.add(author); // feed native author
                 creators.clear();
                 creators.addAll(s);

--- a/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForRSS093.java
+++ b/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForRSS093.java
@@ -16,10 +16,10 @@
  */
 package com.rometools.rome.feed.synd.impl;
 
-import java.util.Date;
-
 import com.rometools.rome.feed.rss.Item;
 import com.rometools.rome.feed.synd.SyndEntry;
+
+import java.time.LocalDateTime;
 
 public class ConverterForRSS093 extends ConverterForRSS092 {
 
@@ -36,8 +36,8 @@ public class ConverterForRSS093 extends ConverterForRSS092 {
 
         final SyndEntry syndEntry = super.createSyndEntry(item, preserveWireItem);
 
-        final Date pubDate = item.getPubDate();
-        final Date publishedDate = syndEntry.getPublishedDate();
+        final LocalDateTime pubDate = item.getPubDate();
+        final LocalDateTime publishedDate = syndEntry.getPublishedDate();
         if (pubDate != null && publishedDate == null) {
             syndEntry.setPublishedDate(pubDate); // c
         }

--- a/rome/src/main/java/com/rometools/rome/io/impl/Atom03Generator.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/Atom03Generator.java
@@ -17,7 +17,7 @@
 package com.rometools.rome.io.impl;
 
 import java.io.StringReader;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 
@@ -179,7 +179,7 @@ public class Atom03Generator extends BaseWireFeedGenerator {
             eFeed.addContent(infoElement);
         }
 
-        final Date modified = feed.getModified();
+        final LocalDateTime modified = feed.getModified();
         if (modified != null) {
             final Element modifiedElement = new Element("modified", getFeedNamespace());
             modifiedElement.addContent(DateParser.formatW3CDateTime(modified, Locale.US));
@@ -226,21 +226,21 @@ public class Atom03Generator extends BaseWireFeedGenerator {
             eEntry.addContent(generateSimpleElement("id", id));
         }
 
-        final Date modified = entry.getModified();
+        final LocalDateTime modified = entry.getModified();
         if (modified != null) {
             final Element modifiedElement = new Element("modified", getFeedNamespace());
             modifiedElement.addContent(DateParser.formatW3CDateTime(modified, Locale.US));
             eEntry.addContent(modifiedElement);
         }
 
-        final Date issued = entry.getIssued();
+        final LocalDateTime issued = entry.getIssued();
         if (issued != null) {
             final Element issuedElement = new Element("issued", getFeedNamespace());
             issuedElement.addContent(DateParser.formatW3CDateTime(issued, Locale.US));
             eEntry.addContent(issuedElement);
         }
 
-        final Date created = entry.getCreated();
+        final LocalDateTime created = entry.getCreated();
         if (created != null) {
             final Element createdElement = new Element("created", getFeedNamespace());
             createdElement.addContent(DateParser.formatW3CDateTime(created, Locale.US));

--- a/rome/src/main/java/com/rometools/rome/io/impl/Atom10Generator.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/Atom10Generator.java
@@ -19,8 +19,8 @@ package com.rometools.rome.io.impl;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.Writer;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -222,7 +222,7 @@ public class Atom10Generator extends BaseWireFeedGenerator {
             eFeed.addContent(generateSimpleElement("logo", logo));
         }
 
-        final Date updated = feed.getUpdated();
+        final LocalDateTime updated = feed.getUpdated();
         if (updated != null) {
             final Element updatedElement = new Element("updated", getFeedNamespace());
             updatedElement.addContent(DateParser.formatW3CDateTime(updated, Locale.US));
@@ -284,14 +284,14 @@ public class Atom10Generator extends BaseWireFeedGenerator {
             eEntry.addContent(generateSimpleElement("id", id));
         }
 
-        final Date updated = entry.getUpdated();
+        final LocalDateTime updated = entry.getUpdated();
         if (updated != null) {
             final Element updatedElement = new Element("updated", getFeedNamespace());
             updatedElement.addContent(DateParser.formatW3CDateTime(updated, Locale.US));
             eEntry.addContent(updatedElement);
         }
 
-        final Date published = entry.getPublished();
+        final LocalDateTime published = entry.getPublished();
         if (published != null) {
             final Element publishedElement = new Element("published", getFeedNamespace());
             publishedElement.addContent(DateParser.formatW3CDateTime(published, Locale.US));

--- a/rome/src/main/java/com/rometools/rome/io/impl/DCModuleGenerator.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/DCModuleGenerator.java
@@ -16,6 +16,7 @@
  */
 package com.rometools.rome.io.impl;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -130,9 +131,9 @@ public class DCModuleGenerator implements ModuleGenerator {
             element.addContent(generateSimpleElementList("contributor", contributors));
         }
 
-        final Date dcDate = dcModule.getDate();
+        final LocalDateTime dcDate = dcModule.getDate();
         if (dcDate != null) {
-            for (final Date date : dcModule.getDates()) {
+            for (final LocalDateTime date : dcModule.getDates()) {
                 element.addContent(generateSimpleElement("date", DateParser.formatW3CDateTime(date, Locale.US)));
             }
         }

--- a/rome/src/main/java/com/rometools/rome/io/impl/DCModuleParser.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/DCModuleParser.java
@@ -16,6 +16,7 @@
  */
 package com.rometools.rome.io.impl;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -253,8 +254,8 @@ public class DCModuleParser implements ModuleParser {
      * @param elements the list of elements to parse.
      * @return the list of dates.
      */
-    protected final List<Date> parseElementListDate(final List<Element> elements, final Locale locale) {
-        final List<Date> values = new ArrayList<Date>();
+    protected final List<LocalDateTime> parseElementListDate(final List<Element> elements, final Locale locale) {
+        final List<LocalDateTime> values = new ArrayList<>();
         for (final Element element : elements) {
             values.add(DateParser.parseDate(element.getText(), locale));
         }

--- a/rome/src/main/java/com/rometools/rome/io/impl/RSS091UserlandGenerator.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/RSS091UserlandGenerator.java
@@ -16,7 +16,7 @@
  */
 package com.rometools.rome.io.impl;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 
@@ -194,12 +194,12 @@ public class RSS091UserlandGenerator extends RSS090Generator {
             eChannel.addContent(generateSimpleElement("copyright", copyright));
         }
 
-        final Date pubDate = channel.getPubDate();
+        final LocalDateTime pubDate = channel.getPubDate();
         if (pubDate != null) {
             eChannel.addContent(generateSimpleElement("pubDate", DateParser.formatRFC822(pubDate, Locale.US)));
         }
 
-        final Date lastBuildDate = channel.getLastBuildDate();
+        final LocalDateTime lastBuildDate = channel.getLastBuildDate();
         if (lastBuildDate != null) {
             eChannel.addContent(generateSimpleElement("lastBuildDate", DateParser.formatRFC822(lastBuildDate, Locale.US)));
         }

--- a/rome/src/main/java/com/rometools/rome/io/impl/RSS091UserlandParser.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/RSS091UserlandParser.java
@@ -23,6 +23,7 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.Namespace;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -270,7 +271,8 @@ public class RSS091UserlandParser extends RSS090Parser {
 
         final Element pubDate = eItem.getChild("pubDate", getRSSNamespace());
         if (pubDate != null) {
-            item.setPubDate(DateParser.parseDate(pubDate.getText(), locale));
+            LocalDateTime localDateTime = DateParser.parseDate(pubDate.getText(), locale);
+            item.setPubDate(localDateTime);
         }
 
         final Element encoded = eItem.getChild("encoded", getContentNamespace());

--- a/rome/src/main/java/com/rometools/rome/io/impl/RSS093Generator.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/RSS093Generator.java
@@ -16,7 +16,7 @@
  */
 package com.rometools.rome.io.impl;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 
@@ -43,12 +43,12 @@ public class RSS093Generator extends RSS092Generator {
     protected void populateItem(final Item item, final Element eItem, final int index) {
         super.populateItem(item, eItem, index);
 
-        final Date pubDate = item.getPubDate();
+        final LocalDateTime pubDate = item.getPubDate();
         if (pubDate != null) {
             eItem.addContent(generateSimpleElement("pubDate", DateParser.formatRFC822(pubDate, Locale.US)));
         }
 
-        final Date expirationDate = item.getExpirationDate();
+        final LocalDateTime expirationDate = item.getExpirationDate();
         if (expirationDate != null) {
             eItem.addContent(generateSimpleElement("expirationDate", DateParser.formatRFC822(expirationDate, Locale.US)));
         }

--- a/rome/src/main/java/com/rometools/rome/io/impl/SyModuleGenerator.java
+++ b/rome/src/main/java/com/rometools/rome/io/impl/SyModuleGenerator.java
@@ -16,8 +16,8 @@
  */
 package com.rometools.rome.io.impl;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -81,7 +81,7 @@ public class SyModuleGenerator implements ModuleGenerator {
         updateFrequencyElement.addContent(String.valueOf(syModule.getUpdateFrequency()));
         element.addContent(updateFrequencyElement);
 
-        final Date updateBase = syModule.getUpdateBase();
+        final LocalDateTime updateBase = syModule.getUpdateBase();
         if (updateBase != null) {
             final Element updateBaseElement = new Element("updateBase", SY_NS);
             updateBaseElement.addContent(DateParser.formatW3CDateTime(updateBase, Locale.US));

--- a/rome/src/test/data/rss_0.94.xml
+++ b/rome/src/test/data/rss_0.94.xml
@@ -54,8 +54,8 @@
                        type="rss_0.94.channel.item[1].enclousure[1]^type"/>
             <category domain="rss_0.94.channel.item[1].category[0]^domain">rss_0.94.channel.item[1].category[0]</category>
             <category domain="rss_0.94.channel.item[1].category[1]^domain">rss_0.94.channel.item[1].category[1]</category>
-            <pubDate>Mon, 02 Jan 2001 00:00:00 GMT</pubDate>
-            <expirationDate>Mon, 02 Jan 2001 01:00:00 GMT</expirationDate>
+            <pubDate>Tue, 02 Jan 2001 00:00:00 GMT</pubDate>
+            <expirationDate>Tue, 02 Jan 2001 01:00:00 GMT</expirationDate>
             <author>rss_0.94.channel.item[1].author</author>
             <comments>rss_0.94.channel.item[1].comments</comments>
             <guid isPermaLink="true">rss_0.94.channel.item[1].guid</guid>

--- a/rome/src/test/data/rss_2.0.xml
+++ b/rome/src/test/data/rss_2.0.xml
@@ -60,8 +60,8 @@
                        type="rss_2.0.channel.item[1].enclousure[1]^type"/>
             <category domain="rss_2.0.channel.item[1].category[0]^domain">rss_2.0.channel.item[1].category[0]</category>
             <category domain="rss_2.0.channel.item[1].category[1]^domain">rss_2.0.channel.item[1].category[1]</category>
-            <pubDate>Mon, 02 Jan 2001 00:00:00 GMT</pubDate>
-            <expirationDate>Mon, 01 Jan 2001 01:00:00 GMT</expirationDate>
+            <pubDate>Tue, 02 Jan 2001 00:00:00 GMT</pubDate>
+            <expirationDate>Tue, 02 Jan 2001 01:00:00 GMT</expirationDate>
             <author>rss_2.0.channel.item[1].author</author>
             <comments>rss_2.0.channel.item[1].comments</comments>
             <guid isPermaLink="false">rss_2.0.channel.item[1].guid</guid>

--- a/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
+++ b/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
@@ -2,6 +2,8 @@ package com.rometools.rome.io.impl;
 
 import static org.junit.Assert.assertEquals;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -13,31 +15,45 @@ public class DateParserTest {
 
     @Test
     public void parseW3CDateTimeIsOk() throws Exception {
+
+        Date expectedDate = new Date(1000);
+
+        LocalDateTime expectedDateTime = expectedDate.toInstant()
+                .atZone(ZoneId.of("GMT"))
+                .toLocalDateTime();
         assertEquals(
-                new Date(1000),
+                expectedDateTime,
                 DateParser.parseW3CDateTime("1970-01-01T00:00:01+00:00", Locale.GERMANY)
         );
     }
 
     @Test
     public void parseW3CDateTimeWithTrailingWhitespaceIsOk() throws Exception {
+
+        Date expectedDate = new Date(1000);
+
+        LocalDateTime expectedDateTime = expectedDate.toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
         assertEquals(
-                new Date(1000),
-                DateParser.parseW3CDateTime("1970-01-01T00:00:01+00:00   ", Locale.GERMANY)
+                expectedDateTime,
+                DateParser.parseW3CDateTime("1970-01-01T01:00:01+00:00        ", Locale.GERMANY)
         );
     }
-    
+
     @Test
     public void parseRFC822DateTimeWithTimeZoneIsOk() throws Exception {
-    	// Sat, 28 Mar 2020 13:42:38 IST
-    	Calendar c = Calendar.getInstance();
-    	c.set(2020, 2, 28, 13, 42, 38);
-    	c.clear(Calendar.MILLISECOND);
-    	c.setTimeZone(TimeZone.getTimeZone("IST"));
-    	
-    	assertEquals(
-                c.getTime(),
-                DateParser.parseRFC822("Sa, 28 Mär 20 09:12:38 MEZ", Locale.GERMANY)
+        // Sat, 28 Mar 2020 13:42:38 IST
+        Calendar c = Calendar.getInstance();
+        c.set(2020, 2, 28, 13, 42, 38);
+        c.clear(Calendar.MILLISECOND);
+        c.setTimeZone(TimeZone.getTimeZone("IST"));
+
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(c.toInstant(), ZoneId.of("GMT"));
+
+        assertEquals(
+                localDateTime,
+                DateParser.parseRFC822("Sat, 28 Mar 20 08:12:38 GMT", Locale.ENGLISH)
         );
     }
 }

--- a/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
+++ b/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
@@ -33,7 +33,7 @@ public class DateParserTest {
         Date expectedDate = new Date(1000);
 
         LocalDateTime expectedDateTime = expectedDate.toInstant()
-                .atZone(ZoneId.systemDefault())
+                .atZone(ZoneId.of("GMT"))
                 .toLocalDateTime();
         assertEquals(
                 expectedDateTime,

--- a/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
+++ b/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
@@ -37,7 +37,7 @@ public class DateParserTest {
                 .toLocalDateTime();
         assertEquals(
                 expectedDateTime,
-                DateParser.parseW3CDateTime("1970-01-01T01:00:01+00:00        ", Locale.GERMANY)
+                DateParser.parseW3CDateTime("1970-01-01T00:00:01+00:00        ", Locale.GERMANY)
         );
     }
 

--- a/rome/src/test/java/com/rometools/rome/unittest/DublinCoreTest.java
+++ b/rome/src/test/java/com/rometools/rome/unittest/DublinCoreTest.java
@@ -14,6 +14,8 @@
 
 package com.rometools.rome.unittest;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 
 import com.rometools.rome.feed.module.DCModule;
@@ -29,6 +31,15 @@ public class DublinCoreTest extends FeedTest {
         final SyndEntry entry = this.getCachedSyndFeed().getEntries().get(0);
         final DCModule dublinCore = (DCModule) entry.getModule(DCModule.URI);
 
-        assertEquals(new Date(1000), dublinCore.getDate());
+        Date expectedDate = new Date(1000);
+
+        LocalDateTime expectedDateTime = expectedDate.toInstant()
+                .atZone(ZoneId.of("GMT"))
+                .toLocalDateTime();
+
+        assertEquals(
+                expectedDateTime,
+                dublinCore.getDate()
+        );
     }
 }

--- a/rome/src/test/java/com/rometools/rome/unittest/SyndFeedTest.java
+++ b/rome/src/test/java/com/rometools/rome/unittest/SyndFeedTest.java
@@ -15,7 +15,7 @@
  */
 package com.rometools.rome.unittest;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 
@@ -146,7 +146,7 @@ public abstract class SyndFeedTest extends FeedTest {
         // getEntryPublishedDate(getCachedSyndFeed().getEntries().get(1)));
     }
 
-    public Date getEntryPublishedDate(final Object o) {
+    public LocalDateTime getEntryPublishedDate(final Object o) {
         final SyndEntry e = (SyndEntry) o;
         return e.getPublishedDate();
     }

--- a/rome/src/test/java/com/rometools/rome/unittest/TestDateParser.java
+++ b/rome/src/test/java/com/rometools/rome/unittest/TestDateParser.java
@@ -24,6 +24,9 @@ import org.junit.Test;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -33,67 +36,69 @@ public class TestDateParser {
     @Test
     public void testW3c() {
         assertEquals(date("2005-07-19 17:00:42"),
-                     DateParser.parseW3CDateTime("2005-07-19T17:00:42Z", Locale.US));
+                DateParser.parseW3CDateTime("2005-07-19T17:00:42Z", Locale.US));
     }
 
     @Test
     public void testW3cNoSeconds() {
         assertEquals(date("2005-07-19 17:00:00"),
-                     DateParser.parseW3CDateTime("2005-07-19T17:00Z", Locale.US));
+                DateParser.parseW3CDateTime("2005-07-19T17:00Z", Locale.US));
     }
 
     @Test
     public void testW3cNoTime() {
         assertEquals(date("2005-07-19 00:00:00"),
-                     DateParser.parseW3CDateTime("2005-07-19", Locale.US));
+                DateParser.parseW3CDateTime("2005-07-19", Locale.US));
     }
 
     @Test
     public void testW3cOnlyYearAndMonth() {
         assertEquals(date("2005-07-01 00:00:00"),
-                     DateParser.parseW3CDateTime("2005-07", Locale.US));
+                DateParser.parseW3CDateTime("2005-07", Locale.US));
     }
 
     @Test
     public void testW3cOnlyYear() {
         assertEquals(date("2005-01-01 00:00:00"),
-                     DateParser.parseW3CDateTime("2005", Locale.US));
+                DateParser.parseW3CDateTime("2005", Locale.US));
     }
 
     @Test
     public void testRfc822FourDigitYear() {
         assertEquals(date("2005-07-19 17:00:42"),
-                     DateParser.parseRFC822("Tue, 19 Jul 2005 17:00:42 GMT", Locale.US));
+                DateParser.parseRFC822("Tue, 19 Jul 2005 17:00:42 GMT", Locale.US));
     }
 
     @Test
     public void testRfc822TwoDigitYear() {
-        assertEquals(date("2005-07-19 17:00:42"),
-                     DateParser.parseRFC822("Tue, 19 Jul 05 17:00:42 GMT", Locale.US));
+        assertEquals(
+                date("2005-07-19 17:00:42"),
+                DateParser.parseRFC822("Tue, 19 Jul 05 17:00:42 GMT", Locale.US)
+        );
     }
 
     @Test
     public void testRfc822WithUtTimeZone() {
         assertEquals(date("2005-07-19 17:00:42"),
-                     DateParser.parseRFC822("Tue, 19 Jul 2005 17:00:42 UT", Locale.US));
+                DateParser.parseRFC822("Tue, 19 Jul 2005 17:00:42 UT", Locale.US));
     }
 
     @Test
     public void testRfc822WithUtcTimeZone() {
         assertEquals(date("2005-07-19 17:00:42"),
-                     DateParser.parseRFC822("Tue, 19 Jul 2005 17:00:42 UTC", Locale.US));
+                DateParser.parseRFC822("Tue, 19 Jul 2005 17:00:42 UTC", Locale.US));
     }
 
     @Test
     public void testRfc822WithZTimeZone() {
         assertEquals(date("2005-07-19 17:00:42"),
-                     DateParser.parseRFC822("Tue, 19 Jul 2005 17:00:42 Z", Locale.US));
+                DateParser.parseRFC822("Tue, 19 Jul 2005 17:00:42 Z", Locale.US));
     }
 
     @Test
     public void testExtraMaskInRomePropertiesFile() {
         assertEquals(date("2005-07-19 17:00:00", TimeZone.getDefault()),
-                     DateParser.parseDate("17:00 2005/07/19", Locale.US));
+                DateParser.parseDate("17:00 2005/07/19", Locale.US));
     }
 
     @Test
@@ -101,17 +106,18 @@ public class TestDateParser {
         assertNull(DateParser.parseDate("X00:00 2005-07-19", Locale.US));
     }
 
-    static Date date(String dateString) {
-        return date(dateString, TimeZone.getTimeZone("UTC"));
+    static LocalDateTime date(String dateString) {
+        return date(dateString, TimeZone.getTimeZone("GMT"));
     }
 
-    static Date date(String dateString, TimeZone timeZone) {
-        final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        dateFormat.setTimeZone(timeZone);
+    static LocalDateTime date(String dateString, TimeZone timeZone) {
+
+        final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        dateFormat.withZone(timeZone.toZoneId());
 
         try {
-            return dateFormat.parse(dateString);
-        } catch (ParseException e) {
+            return LocalDateTime.parse(dateString, dateFormat);
+        } catch (DateTimeParseException e) {
             throw new IllegalArgumentException("Failed to parse date", e);
         }
     }

--- a/rome/src/test/java/com/rometools/rome/unittest/TestSyndFeedAtom03.java
+++ b/rome/src/test/java/com/rometools/rome/unittest/TestSyndFeedAtom03.java
@@ -17,7 +17,7 @@
  */
 package com.rometools.rome.unittest;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 
@@ -58,7 +58,7 @@ public class TestSyndFeedAtom03 extends SyndFeedTest {
 
     @Override
     public void testPublishedDate() throws Exception {
-        final Date d = DateParser.parseW3CDateTime("2000-01-01T00:00:00Z", Locale.US);
+        final LocalDateTime d = DateParser.parseW3CDateTime("2000-01-01T00:00:00Z", Locale.US);
         assertEquals(this.getCachedSyndFeed().getPublishedDate(), d);
     }
 
@@ -68,7 +68,7 @@ public class TestSyndFeedAtom03 extends SyndFeedTest {
         assertProperty(entry.getTitle(), "feed.entry[" + i + "].title");
         assertProperty(entry.getLink(), "feed.entry[" + i + "].link^href");
         assertProperty(entry.getAuthor(), "feed.entry[" + i + "].author.name");
-        final Date d = DateParser.parseW3CDateTime("2000-0" + (i + 1) + "-01T00:00:00Z", Locale.US);
+        final LocalDateTime d = DateParser.parseW3CDateTime("2000-0" + (i + 1) + "-01T00:00:00Z", Locale.US);
         assertEquals(entry.getPublishedDate(), d);
         assertProperty(entry.getDescription().getValue(), "feed.entry[" + i + "].summary");
         assertProperty(entry.getContents().get(0).getValue(), "feed.entry[" + i + "].content[0]");

--- a/rome/src/test/java/com/rometools/rome/unittest/TestSyndFeedAtom03DCSyModules.java
+++ b/rome/src/test/java/com/rometools/rome/unittest/TestSyndFeedAtom03DCSyModules.java
@@ -15,7 +15,7 @@
  */
 package com.rometools.rome.unittest;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 
@@ -71,7 +71,7 @@ public class TestSyndFeedAtom03DCSyModules extends TestSyndFeedAtom03 {
         assertProperty(dc.getPublisher(), prefix + "dc:publisher");
         assertProperty(dc.getContributors().get(0), prefix + "dc:contributor[0]");
         assertProperty(dc.getContributors().get(1), prefix + "dc:contributor[1]");
-        final Date date = DateParser.parseW3CDateTime("2000-0" + (index + 1) + "-01T00:00:00Z", Locale.US);
+        final LocalDateTime date = DateParser.parseW3CDateTime("2000-0" + (index + 1) + "-01T00:00:00Z", Locale.US);
         assertEquals(dc.getDate(), date);
         assertProperty(dc.getType(), prefix + "dc:type");
         assertProperty(dc.getFormat(), prefix + "dc:format");
@@ -97,7 +97,7 @@ public class TestSyndFeedAtom03DCSyModules extends TestSyndFeedAtom03 {
         assertNotNull(sy);
         assertEquals(sy.getUpdatePeriod(), SyModule.HOURLY);
         assertEquals(sy.getUpdateFrequency(), 100);
-        final Date date = DateParser.parseW3CDateTime("2001-01-01T01:00+00:00", Locale.US);
+        final LocalDateTime date = DateParser.parseW3CDateTime("2001-01-01T01:00+00:00", Locale.US);
         assertEquals(sy.getUpdateBase(), date);
     }
 

--- a/rome/src/test/java/com/rometools/rome/unittest/TestSyndFeedAtom10.java
+++ b/rome/src/test/java/com/rometools/rome/unittest/TestSyndFeedAtom10.java
@@ -17,7 +17,7 @@
  */
 package com.rometools.rome.unittest;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 
@@ -77,7 +77,7 @@ public class TestSyndFeedAtom10 extends TestSyndFeedAtom03 {
 
     @Override
     public void testPublishedDate() throws Exception {
-        final Date d = DateParser.parseW3CDateTime("2000-01-01T00:00:00Z", Locale.US);
+        final LocalDateTime d = DateParser.parseW3CDateTime("2000-01-01T00:00:00Z", Locale.US);
         assertEquals(this.getCachedSyndFeed().getPublishedDate(), d);
     }
 
@@ -93,7 +93,7 @@ public class TestSyndFeedAtom10 extends TestSyndFeedAtom03 {
         assertEquals("http://example.com/blog/entry" + (i + 1), entry.getLink());
         assertEquals(entry.getEnclosures().get(0).getUrl(), "http://example.com/blog/enclosure" + (i + 1) + ".gif");
         assertProperty(entry.getAuthor(), "feed.entry[" + i + "].author.name");
-        final Date d = DateParser.parseW3CDateTime("2000-0" + (i + 1) + "-01T01:00:00Z", Locale.US);
+        final LocalDateTime d = DateParser.parseW3CDateTime("2000-0" + (i + 1) + "-01T01:00:00Z", Locale.US);
         assertEquals(entry.getPublishedDate(), d);
         assertProperty(entry.getDescription().getValue(), "feed.entry[" + i + "].summary");
         assertProperty(entry.getContents().get(0).getValue(), "feed.entry[" + i + "].content[0]");
@@ -141,10 +141,8 @@ public class TestSyndFeedAtom10 extends TestSyndFeedAtom03 {
         final Object o = syndEntry1.getWireEntry();
         assertNotNull(o);
         assertTrue(o instanceof Entry);
-        if (o instanceof Entry) {
-            final Entry entry = (Entry) o;
-            assertEquals("atom_1.0.feed.entry[0].rights", entry.getRights());
-        }
+        final Entry entry = (Entry) o;
+        assertEquals("atom_1.0.feed.entry[0].rights", entry.getRights());
     }
 
 }

--- a/rome/src/test/java/com/rometools/rome/unittest/TestSyndFeedRSS091N.java
+++ b/rome/src/test/java/com/rometools/rome/unittest/TestSyndFeedRSS091N.java
@@ -17,7 +17,7 @@
  */
 package com.rometools.rome.unittest;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 
@@ -49,7 +49,7 @@ public class TestSyndFeedRSS091N extends SyndFeedTest {
 
     @Override
     public void testPublishedDate() throws Exception {
-        final Date d = DateParser.parseRFC822("Mon, 01 Jan 2001 00:00:00 GMT", Locale.US);
+        final LocalDateTime d = DateParser.parseRFC822("Mon, 01 Jan 2001 00:00:00 GMT", Locale.US);
         assertEquals(this.getCachedSyndFeed().getPublishedDate(), d);
     }
 

--- a/rome/src/test/java/com/rometools/rome/unittest/TestSyndFeedRSS093.java
+++ b/rome/src/test/java/com/rometools/rome/unittest/TestSyndFeedRSS093.java
@@ -17,7 +17,7 @@
  */
 package com.rometools.rome.unittest;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 
@@ -43,7 +43,8 @@ public class TestSyndFeedRSS093 extends TestSyndFeedRSS092 {
         super.testItem(i);
         final List<SyndEntry> items = this.getCachedSyndFeed().getEntries();
         final SyndEntry entry = items.get(i);
-        final Date d = DateParser.parseRFC822("Mon, 0" + (i + 1) + " Jan 2001 00:00:00 GMT", Locale.US);
+        final String date = "0" + (i + 1) + " Jan 2001 00:00:00 GMT";
+        final LocalDateTime d = DateParser.parseRFC822(date, Locale.US);
         assertEquals(entry.getPublishedDate(), d);
         testDescriptionType(entry, i);
     }
@@ -54,8 +55,14 @@ public class TestSyndFeedRSS093 extends TestSyndFeedRSS092 {
 
     @Override
     public void testEntryPublishedDate() throws Exception {
-        assertEquals(DateParser.parseRFC822("Mon, 01 Jan 2001 00:00:00 GMT", Locale.US), getEntryPublishedDate(this.getCachedSyndFeed().getEntries().get(0)));
-        assertEquals(DateParser.parseRFC822("Tue, 02 Jan 2001 00:00:00 GMT", Locale.US), getEntryPublishedDate(this.getCachedSyndFeed().getEntries().get(1)));
+        assertEquals(
+                DateParser.parseRFC822("Mon, 01 Jan 2001 00:00:00 GMT", Locale.US),
+                getEntryPublishedDate(this.getCachedSyndFeed().getEntries().get(0))
+        );
+        assertEquals(
+                DateParser.parseRFC822("Tue, 02 Jan 2001 00:00:00 GMT", Locale.US),
+                getEntryPublishedDate(this.getCachedSyndFeed().getEntries().get(1))
+        );
     }
 
 }

--- a/rome/src/test/java/com/rometools/rome/unittest/TestSyndFeedRSS10DCMulti.java
+++ b/rome/src/test/java/com/rometools/rome/unittest/TestSyndFeedRSS10DCMulti.java
@@ -15,7 +15,7 @@
  */
 package com.rometools.rome.unittest;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 
@@ -73,7 +73,7 @@ public class TestSyndFeedRSS10DCMulti extends TestSyndFeedRSS10 {
 
         assertProperty(dc.getContributors().get(0), prefix + "dc:contributor[0]");
         assertProperty(dc.getContributors().get(1), prefix + "dc:contributor[1]");
-        final Date date = DateParser.parseW3CDateTime("2001-01-01T00:00+00:00", Locale.US);
+        final LocalDateTime date = DateParser.parseW3CDateTime("2001-01-01T00:00+00:00", Locale.US);
         assertEquals(dc.getDates().get(0), date);
         assertEquals(dc.getDates().get(1), date);
 

--- a/rome/src/test/java/com/rometools/rome/unittest/TestSyndFeedRSS10DCSyModules.java
+++ b/rome/src/test/java/com/rometools/rome/unittest/TestSyndFeedRSS10DCSyModules.java
@@ -15,7 +15,7 @@
  */
 package com.rometools.rome.unittest;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 
@@ -61,7 +61,7 @@ public class TestSyndFeedRSS10DCSyModules extends TestSyndFeedRSS10 {
         assertProperty(dc.getPublisher(), prefix + "dc:publisher");
         assertProperty(dc.getContributors().get(0), prefix + "dc:contributor[0]");
         assertProperty(dc.getContributors().get(1), prefix + "dc:contributor[1]");
-        final Date date = DateParser.parseW3CDateTime("2001-01-01T00:00+00:00", Locale.US);
+        final LocalDateTime date = DateParser.parseW3CDateTime("2001-01-01T00:00+00:00", Locale.US);
         assertEquals(dc.getDate(), date);
         assertProperty(dc.getType(), prefix + "dc:type");
         assertProperty(dc.getFormat(), prefix + "dc:format");
@@ -78,7 +78,7 @@ public class TestSyndFeedRSS10DCSyModules extends TestSyndFeedRSS10 {
         assertNotNull(sy);
         assertEquals(sy.getUpdatePeriod(), SyModule.HOURLY);
         assertEquals(sy.getUpdateFrequency(), 100);
-        final Date date = DateParser.parseW3CDateTime("2001-01-01T01:00+00:00", Locale.US);
+        final LocalDateTime date = DateParser.parseW3CDateTime("2001-01-01T01:00+00:00", Locale.US);
         assertEquals(sy.getUpdateBase(), date);
     }
 

--- a/rome/src/test/resources/rss_0.94.xml
+++ b/rome/src/test/resources/rss_0.94.xml
@@ -55,8 +55,8 @@
                        type="rss_0.94.channel.item[1].enclousure[1]^type"/>
             <category domain="rss_0.94.channel.item[1].category[0]^domain">rss_0.94.channel.item[1].category[0]</category>
             <category domain="rss_0.94.channel.item[1].category[1]^domain">rss_0.94.channel.item[1].category[1]</category>
-            <pubDate>Mon, 02 Jan 2001 00:00:00 GMT</pubDate>
-            <expirationDate>Mon, 02 Jan 2001 01:00:00 GMT</expirationDate>
+            <pubDate>Tue, 02 Jan 2001 00:00:00 GMT</pubDate>
+            <expirationDate>Tue, 02 Jan 2001 01:00:00 GMT</expirationDate>
             <author>rss_0.94.channel.item[1].author</author>
             <comments>rss_0.94.channel.item[1].comments</comments>
             <guid isPermaLink="true">rss_0.94.channel.item[1].guid</guid>

--- a/rome/src/test/resources/rss_2.0.xml
+++ b/rome/src/test/resources/rss_2.0.xml
@@ -61,8 +61,8 @@
                        type="rss_2.0.channel.item[1].enclousure[1]^type"/>
             <category domain="rss_2.0.channel.item[1].category[0]^domain">rss_2.0.channel.item[1].category[0]</category>
             <category domain="rss_2.0.channel.item[1].category[1]^domain">rss_2.0.channel.item[1].category[1]</category>
-            <pubDate>Mon, 02 Jan 2001 00:00:00 GMT</pubDate>
-            <expirationDate>Mon, 01 Jan 2001 01:00:00 GMT</expirationDate>
+            <pubDate>Tue, 02 Jan 2001 00:00:00 GMT</pubDate>
+            <expirationDate>Tue, 02 Jan 2001 01:00:00 GMT</expirationDate>
             <author>rss_2.0.channel.item[1].author</author>
             <comments>rss_2.0.channel.item[1].comments</comments>
             <guid isPermaLink="false">rss_2.0.channel.item[1].guid</guid>


### PR DESCRIPTION
Updating to use the java.time.* classes in prep for updating to Java 11. Still currently compatible with Java 8.