### PR TITLE
Feature/date format test

### DIFF
--- a/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
+++ b/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
@@ -2,6 +2,7 @@ package com.rometools.rome.io.impl;
 
 import static org.junit.Assert.assertEquals;
 
+import java.text.DateFormatSymbols;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -34,10 +35,16 @@ public class DateParserTest {
     	c.set(2020, Calendar.MARCH, 28, 13, 42, 38);
     	c.clear(Calendar.MILLISECOND);
     	c.setTimeZone(TimeZone.getTimeZone("IST"));
-    	
+        DateFormatSymbols german = new DateFormatSymbols(Locale.GERMANY);
+        String saturday = german.getShortWeekdays()[7];
+        String march = german.getShortMonths()[2];
+
     	assertEquals(
                 c.getTime(),
-                DateParser.parseRFC822("Sa, 28 Mär 20 09:12:38 MEZ", Locale.GERMANY)
+                DateParser.parseRFC822(
+                    String.format("%s, 28 %s 20 09:12:38 MEZ", saturday, march),
+                    Locale.GERMANY
+                )
         );
     }
 }

--- a/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
+++ b/rome/src/test/java/com/rometools/rome/io/impl/DateParserTest.java
@@ -31,7 +31,7 @@ public class DateParserTest {
     public void parseRFC822DateTimeWithTimeZoneIsOk() throws Exception {
     	// Sat, 28 Mar 2020 13:42:38 IST
     	Calendar c = Calendar.getInstance();
-    	c.set(2020, 2, 28, 13, 42, 38);
+    	c.set(2020, Calendar.MARCH, 28, 13, 42, 38);
     	c.clear(Calendar.MILLISECOND);
     	c.setTimeZone(TimeZone.getTimeZone("IST"));
     	


### PR DESCRIPTION
The test `parseRFC822DateTimeWithTimeZoneIsOk` depends on locale strings that have changed in more recent versions of Java. This change makes the test case use the strings from `DateFormatSymbols` so that it works on both Java 8 and Java 11+.